### PR TITLE
Add silent auth token refresh for browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ app.listen(3000, function() {
 You should be able to issue new accessToken by simply calling:
 
 ```typescript
-await token.refresh((newToken) => { ... });
+const token = await client.auth.refresh();
+```
+
+Optionally, this method accepts a number as an argument to specify after how many milliseconds the refresh request should timeout (default is 10000):
+
+```typescript
+// abort after 20 seconds
+const token = await client.auth.refresh(20000);
 ```
 
 ## Usage (Browser)
@@ -125,14 +132,14 @@ await token.refresh((newToken) => { ... });
 Kontist SDK allows renewing access tokens in browser environments using this simple method:
 
 ```typescript
-const token = await kontistClient.auth.refreshTokenSilently();
+const token = await client.auth.refresh();
 ```
 
 Optionally, this method accepts a number as an argument to specify after how many milliseconds the refresh request should timeout (default is 10000):
 
 ```typescript
 // abort after 20 seconds
-const token = await kontistClient.auth.refreshTokenSilently(20000);
+const token = await client.auth.refresh(20000);
 ```
 
 ### Password-based authentication

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ Kontist SDK allows renewing access tokens in browser environments using this sim
 const token = await kontistClient.auth.refreshTokenSilently();
 ```
 
+Optionally, this method accepts a number as an argument to specify after how many milliseconds the refresh request should timeout (default is 10000):
+
+```typescript
+// abort after 20 seconds
+const token = await kontistClient.auth.refreshTokenSilently(20000);
+```
+
 ### Password-based authentication
 
 If you'd rather handle the authentication UI flow in your app, and when your oAuth2 client supports `grant_type: password`, you could request an access token in exchange for a user's credentials in one step:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ await token.refresh((newToken) => { ... });
 </html>
 ```
 
+Kontist SDK allows renewing access tokens in browser environments using this simple method:
+
+```typescript
+const token = await kontistClient.auth.refreshTokenSilently();
+```
+
 ### Password-based authentication
 
 If you'd rather handle the authentication UI flow in your app, and when your oAuth2 client supports `grant_type: password`, you could request an access token in exchange for a user's credentials in one step:
@@ -136,7 +142,7 @@ const client = new Kontist.Client({
 client.auth.fetchTokenFromCredentials({ username, password })
 	.then((tokenData) => {
 	  // do something with tokenData.accessToken
-	  // 
+	  //
 	  // or start using client to make authenticated requests
 	});
 ```

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -174,7 +174,9 @@ export class Auth {
   /**
    * Refresh auth token silently for browser environments
    */
-  public refreshTokenSilently = async (timeout?: number): Promise<ClientOAuth2.Token> => {
+  public refreshTokenSilently = async (
+    timeout?: number
+  ): Promise<ClientOAuth2.Token> => {
     if (!document || !window) {
       throw new SilentAuthorizationError({
         message:
@@ -191,7 +193,9 @@ export class Auth {
 
     try {
       const code = await authorizeSilently(iframeUri, this.baseUrl, timeout);
-      const fetchTokenUri = `${document.location.origin}?code=${code}&state=${this.state}`;
+      const fetchTokenUri = `${
+        document.location.origin
+      }?code=${code}&state=${encodeURIComponent(this.state)}`;
       const token = await this.fetchToken(fetchTokenUri);
 
       return token;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -174,7 +174,7 @@ export class Auth {
   /**
    * Refresh auth token silently for browser environments
    */
-  public refreshTokenSilently = async (): Promise<ClientOAuth2.Token> => {
+  public refreshTokenSilently = async (timeout?: number): Promise<ClientOAuth2.Token> => {
     if (!document || !window) {
       throw new SilentAuthorizationError({
         message:
@@ -190,7 +190,7 @@ export class Auth {
     });
 
     try {
-      const code = await authorizeSilently(iframeUri, this.baseUrl);
+      const code = await authorizeSilently(iframeUri, this.baseUrl, timeout);
       const fetchTokenUri = `${document.location.origin}?code=${code}&state=${this.state}`;
       const token = await this.fetchToken(fetchTokenUri);
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -8,7 +8,7 @@ export enum ErrorMessage {
   CHALLENGE_EXPIRED_ERROR = "Challenge expired",
   CHALLENGE_DENIED_ERROR = "Challenge denied",
   MFA_CONFIRMATION_CANCELED_ERROR = "MFA confirmation canceled",
-  SILENT_AUTHORIZATION_ERROR = "Silent authorization failed",
+  RENEW_TOKEN_ERROR = "Token renewal failed",
   USER_UNAUTHORIZED_ERROR = "User unauthorized"
 }
 
@@ -72,13 +72,13 @@ export class UserUnauthorizedError extends KontistSDKError {
   }
 }
 
-export class SilentAuthorizationError extends KontistSDKError {
+export class RenewTokenError extends KontistSDKError {
   constructor(opts: ErrorOpts = {}) {
     super({
-      message: ErrorMessage.SILENT_AUTHORIZATION_ERROR,
+      message: ErrorMessage.RENEW_TOKEN_ERROR,
       ...opts
     });
-    Object.setPrototypeOf(this, SilentAuthorizationError.prototype);
+    Object.setPrototypeOf(this, RenewTokenError.prototype);
     this.name = this.constructor.name;
   }
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -8,6 +8,7 @@ export enum ErrorMessage {
   CHALLENGE_EXPIRED_ERROR = "Challenge expired",
   CHALLENGE_DENIED_ERROR = "Challenge denied",
   MFA_CONFIRMATION_CANCELED_ERROR = "MFA confirmation canceled",
+  SILENT_AUTHORIZATION_ERROR = "Silent authorization failed",
   USER_UNAUTHORIZED_ERROR = "User unauthorized"
 }
 
@@ -67,6 +68,17 @@ export class UserUnauthorizedError extends KontistSDKError {
       status: ErrorStatus.USER_UNAUTHORIZED_ERROR
     });
     Object.setPrototypeOf(this, UserUnauthorizedError.prototype);
+    this.name = this.constructor.name;
+  }
+}
+
+export class SilentAuthorizationError extends KontistSDKError {
+  constructor(opts: ErrorOpts = {}) {
+    super({
+      message: ErrorMessage.SILENT_AUTHORIZATION_ERROR,
+      ...opts
+    });
+    Object.setPrototypeOf(this, SilentAuthorizationError.prototype);
     this.name = this.constructor.name;
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,21 @@
 import * as ClientOAuth2 from "client-oauth2";
 
+export enum ChallengeStatus {
+  PENDING = "PENDING",
+  VERIFIED = "VERIFIED",
+  DENIED = "DENIED"
+}
+
+export enum HttpMethod {
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
+  PATCH = "PATCH",
+  OPTIONS = "OPTIONS",
+  HEAD = "HEAD",
+  DELETE = "DELETE"
+}
+
 export type ClientOpts = {
   baseUrl?: string;
   clientId: string;
@@ -17,20 +33,10 @@ export type Challenge = {
   status: ChallengeStatus;
 };
 
-export enum ChallengeStatus {
-  PENDING = "PENDING",
-  VERIFIED = "VERIFIED",
-  DENIED = "DENIED"
-}
-
-export enum HttpMethod {
-  GET = "GET",
-  POST = "POST",
-  PUT = "PUT",
-  PATCH = "PATCH",
-  OPTIONS = "OPTIONS",
-  HEAD = "HEAD",
-  DELETE = "DELETE"
+export type GetAuthUriOpts = {
+  query?: {
+    [key: string]: string | string[];
+  }
 }
 
 export type CreateDeviceParams = {
@@ -60,3 +66,5 @@ export type VerifyDeviceChallengeParams = {
 export type VerifyDeviceChallengeResult = {
   token: string;
 };
+
+export type TimeoutID = ReturnType<typeof setTimeout>;

--- a/lib/utils/authorizeSilently.ts
+++ b/lib/utils/authorizeSilently.ts
@@ -3,7 +3,11 @@ import { TimeoutID } from "../types";
 
 const DEFAULT_SERVER_MESSAGE_TIMEOUT = 10000;
 
-export const authorizeSilently = (uri: string, origin: string, timeout?: number) => {
+export const authorizeSilently = (
+  uri: string,
+  origin: string,
+  timeout?: number
+) => {
   return new Promise((resolve, reject) => {
     let timeoutId: TimeoutID;
     const iframe = document.createElement("iframe");
@@ -27,11 +31,16 @@ export const authorizeSilently = (uri: string, origin: string, timeout?: number)
 
       cleanup();
 
-      if (!event.data.error) {
+      if (event.data && !event.data.error) {
         const { code } = event.data.response;
         return resolve(code);
       } else {
-        return reject(event.data.error);
+        const error =
+          (event.data && event.data.error) ||
+          new SilentAuthorizationError({
+            message: "Invalid message received from server"
+          });
+        return reject(error);
       }
     };
 

--- a/lib/utils/authorizeSilently.ts
+++ b/lib/utils/authorizeSilently.ts
@@ -1,0 +1,52 @@
+import { SilentAuthorizationError } from "../errors";
+import { TimeoutID } from "../types";
+
+const SERVER_MESSAGE_TIMEOUT = 10000;
+
+export const authorizeSilently = (uri: string, origin: string) => {
+  return new Promise((resolve, reject) => {
+    let timeoutId: TimeoutID;
+    const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    document.body.appendChild(iframe);
+
+    const cleanup = () => {
+      window.removeEventListener("message", onMessageHandler);
+      if (iframe && iframe.parentNode) {
+        iframe.parentNode.removeChild(iframe);
+      }
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const onMessageHandler = (event: MessageEvent) => {
+      if (event.origin !== origin) {
+        return;
+      }
+
+      cleanup();
+
+      if (!event.data.error) {
+        const { code } = event.data.response;
+        return resolve(code);
+      } else {
+        return reject(event.data.error);
+      }
+    };
+
+    window.addEventListener("message", onMessageHandler);
+    if (iframe) {
+      iframe.src = uri;
+    }
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      return reject(
+        new SilentAuthorizationError({
+          message: "Server did not respond with authorization code, aborting."
+        })
+      );
+    }, SERVER_MESSAGE_TIMEOUT);
+  });
+};

--- a/lib/utils/authorizeSilently.ts
+++ b/lib/utils/authorizeSilently.ts
@@ -1,12 +1,10 @@
-import { SilentAuthorizationError } from "../errors";
+import { RenewTokenError } from "../errors";
 import { TimeoutID } from "../types";
-
-const DEFAULT_SERVER_MESSAGE_TIMEOUT = 10000;
 
 export const authorizeSilently = (
   uri: string,
   origin: string,
-  timeout?: number
+  timeout: number
 ) => {
   return new Promise((resolve, reject) => {
     let timeoutId: TimeoutID;
@@ -37,7 +35,7 @@ export const authorizeSilently = (
       } else {
         const error =
           (event.data && event.data.error) ||
-          new SilentAuthorizationError({
+          new RenewTokenError({
             message: "Invalid message received from server"
           });
         return reject(error);
@@ -50,10 +48,10 @@ export const authorizeSilently = (
     timeoutId = setTimeout(() => {
       cleanup();
       return reject(
-        new SilentAuthorizationError({
+        new RenewTokenError({
           message: "Server did not respond with authorization code, aborting."
         })
       );
-    }, timeout || DEFAULT_SERVER_MESSAGE_TIMEOUT);
+    }, timeout);
   });
 };

--- a/lib/utils/authorizeSilently.ts
+++ b/lib/utils/authorizeSilently.ts
@@ -1,9 +1,9 @@
 import { SilentAuthorizationError } from "../errors";
 import { TimeoutID } from "../types";
 
-const SERVER_MESSAGE_TIMEOUT = 10000;
+const DEFAULT_SERVER_MESSAGE_TIMEOUT = 10000;
 
-export const authorizeSilently = (uri: string, origin: string) => {
+export const authorizeSilently = (uri: string, origin: string, timeout?: number) => {
   return new Promise((resolve, reject) => {
     let timeoutId: TimeoutID;
     const iframe = document.createElement("iframe");
@@ -47,6 +47,6 @@ export const authorizeSilently = (uri: string, origin: string) => {
           message: "Server did not respond with authorization code, aborting."
         })
       );
-    }, SERVER_MESSAGE_TIMEOUT);
+    }, timeout || DEFAULT_SERVER_MESSAGE_TIMEOUT);
   });
 };

--- a/lib/utils/authorizeSilently.ts
+++ b/lib/utils/authorizeSilently.ts
@@ -36,9 +36,7 @@ export const authorizeSilently = (uri: string, origin: string, timeout?: number)
     };
 
     window.addEventListener("message", onMessageHandler);
-    if (iframe) {
-      iframe.src = uri;
-    }
+    iframe.src = uri;
 
     timeoutId = setTimeout(() => {
       cleanup();

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./authorizeSilently";

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -452,6 +452,7 @@ describe("Auth", () => {
     it("should request a silent authorization and fetch a new token", async () => {
       const dummyToken = "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
       const client = createClient();
+      const customTimeout = 20000;
       const tokenResponseData = {
         access_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
         refresh_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ1",
@@ -468,7 +469,7 @@ describe("Auth", () => {
         .stub(utils, "authorizeSilently")
         .resolves(code);
 
-      const token = await client.auth.refreshTokenSilently();
+      const token = await client.auth.refreshTokenSilently(customTimeout);
 
       expect(fetchTokenStub.callCount).to.equal(1);
       expect(fetchTokenStub.getCall(0).args[0]).to.equal(
@@ -476,10 +477,11 @@ describe("Auth", () => {
       );
 
       expect(silentAuthorizationStub.callCount).to.equal(1);
-      const [firstArg, secondArg] = silentAuthorizationStub.getCall(0).args;
+      const [firstArg, secondArg, thirdArg] = silentAuthorizationStub.getCall(0).args;
       expect(firstArg).to.include("prompt=none");
       expect(firstArg).to.include("response_mode=web_message");
       expect(secondArg).to.equal(Constants.KONTIST_API_BASE_URL);
+      expect(thirdArg).to.equal(customTimeout);
 
       expect(token.accessToken).to.equal(dummyToken);
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -451,7 +451,10 @@ describe("Auth", () => {
 
     it("should request a silent authorization and fetch a new token", async () => {
       const dummyToken = "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
-      const client = createClient();
+      const state = "some?state&with#uri=components";
+      const client = createClient({
+        state
+      });
       const customTimeout = 20000;
       const tokenResponseData = {
         access_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -473,11 +476,13 @@ describe("Auth", () => {
 
       expect(fetchTokenStub.callCount).to.equal(1);
       expect(fetchTokenStub.getCall(0).args[0]).to.equal(
-        `${origin}?code=${code}&state=${state}`
+        `${origin}?code=${code}&state=${encodeURIComponent(state)}`
       );
 
       expect(silentAuthorizationStub.callCount).to.equal(1);
-      const [firstArg, secondArg, thirdArg] = silentAuthorizationStub.getCall(0).args;
+      const [firstArg, secondArg, thirdArg] = silentAuthorizationStub.getCall(
+        0
+      ).args;
       expect(firstArg).to.include("prompt=none");
       expect(firstArg).to.include("response_mode=web_message");
       expect(secondArg).to.equal(Constants.KONTIST_API_BASE_URL);

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -439,59 +439,93 @@ describe("Auth", () => {
     });
   });
 
-  describe("client.auth.refreshTokenSilently()", () => {
-    const origin = "http://some.url";
-    const code = "some-random-code";
-    (global as any).window = {};
-    (global as any).document = {
-      location: {
-        origin
-      }
-    };
-
-    it("should request a silent authorization and fetch a new token", async () => {
-      const dummyToken = "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
-      const state = "some?state&with#uri=components";
-      const client = createClient({
-        state
-      });
-      const customTimeout = 20000;
-      const tokenResponseData = {
-        access_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
-        refresh_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ1",
-        token_type: "Bearer"
+  describe("client.auth.refresh()", () => {
+    describe("when client is created with a verifier", () => {
+      const origin = "http://some.url";
+      const code = "some-random-code";
+      (global as any).window = {};
+      (global as any).document = {
+        location: {
+          origin
+        }
       };
+
+      it("should request a silent authorization and fetch a new token", async () => {
+        const dummyToken = "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        const state = "some?state&with#uri=components";
+        const client = createClient({
+          verifier,
+          state
+        });
+        const customTimeout = 20000;
+        const tokenResponseData = {
+          access_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+          token_type: "Bearer"
+        };
+        const oauthClient = new ClientOAuth2({});
+        const fetchTokenStub = sinon
+          .stub(client.auth, "fetchToken")
+          .callsFake(async () => {
+            return new ClientOAuth2.Token(oauthClient, tokenResponseData);
+          });
+
+        const silentAuthorizationStub = sinon
+          .stub(utils, "authorizeSilently")
+          .resolves(code);
+
+        const token = await client.auth.refresh(customTimeout);
+
+        expect(fetchTokenStub.callCount).to.equal(1);
+        expect(fetchTokenStub.getCall(0).args[0]).to.equal(
+          `${origin}?code=${code}&state=${encodeURIComponent(state)}`
+        );
+
+        expect(silentAuthorizationStub.callCount).to.equal(1);
+        const [firstArg, secondArg, thirdArg] = silentAuthorizationStub.getCall(
+          0
+        ).args;
+        expect(firstArg).to.include("prompt=none");
+        expect(firstArg).to.include("response_mode=web_message");
+        expect(secondArg).to.equal(Constants.KONTIST_API_BASE_URL);
+        expect(thirdArg).to.equal(customTimeout);
+
+        expect(token.accessToken).to.equal(dummyToken);
+
+        fetchTokenStub.restore();
+        silentAuthorizationStub.restore();
+      });
+    });
+
+    describe("when client is created with a clientSecret", () => {
+      it("should request a new token using refresh token", async () => {
       const oauthClient = new ClientOAuth2({});
-      const fetchTokenStub = sinon
-        .stub(client.auth, "fetchToken")
-        .callsFake(async () => {
+
+        const client = createClient({
+          oauthClient,
+          clientSecret
+        });
+
+        const tokenResponseData = {
+          access_token: "dummy-access-token-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+          refresh_token: "dummy-refresh-token-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ1",
+          token_type: "Bearer"
+        };
+
+        client.auth.setToken(
+          tokenResponseData.access_token,
+          tokenResponseData.refresh_token
+        );
+
+        const clientOAuth2TokenRefreshStub = sinon.stub(ClientOAuth2.Token.prototype, "refresh").callsFake(async () => {
           return new ClientOAuth2.Token(oauthClient, tokenResponseData);
         });
 
-      const silentAuthorizationStub = sinon
-        .stub(utils, "authorizeSilently")
-        .resolves(code);
+        await client.auth.refresh();
 
-      const token = await client.auth.refreshTokenSilently(customTimeout);
+        expect(clientOAuth2TokenRefreshStub.callCount).to.equal(1);
 
-      expect(fetchTokenStub.callCount).to.equal(1);
-      expect(fetchTokenStub.getCall(0).args[0]).to.equal(
-        `${origin}?code=${code}&state=${encodeURIComponent(state)}`
-      );
-
-      expect(silentAuthorizationStub.callCount).to.equal(1);
-      const [firstArg, secondArg, thirdArg] = silentAuthorizationStub.getCall(
-        0
-      ).args;
-      expect(firstArg).to.include("prompt=none");
-      expect(firstArg).to.include("response_mode=web_message");
-      expect(secondArg).to.equal(Constants.KONTIST_API_BASE_URL);
-      expect(thirdArg).to.equal(customTimeout);
-
-      expect(token.accessToken).to.equal(dummyToken);
-
-      fetchTokenStub.restore();
-      silentAuthorizationStub.restore();
+        clientOAuth2TokenRefreshStub.restore();
+      });
     });
   });
 });


### PR DESCRIPTION
In this PR we are adding an auth method to refresh the user's access token using `response_mode=web_message` implemented in our backend recently: https://github.com/kontist/figure-backend/pull/5821

You can test the flow by first authenticating using regular login, and then calling the new `refreshTokenSilently()` method:
```
    const url = await kontistClient.auth.getAuthUri();
    window.location.href = url;
    ...
    const token = await kontistClient.auth.refreshTokenSilently();
```

I have shamelessly forked @dmytroyarmak PKCE test application and added these methods if you want to get an easier time testing: https://github.com/hihuz/pkce-demo
just make sure that data in `config.js` is correct against your database: you need an oauth client with proper redirect uri, scopes (`users`) and grant_types (`authorization_code`)