### PR TITLE
Fetch access token with credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ await token.refresh((newToken) => { ... });
 If you'd rather handle the authentication UI flow in your app, and when your oAuth2 client supports `grant_type: password`, you could request an access token in exchange for a user's credentials in one step:
 
 ```javascript
-const client = new Client({
+const client = new Kontist.Client({
   baseUrl: "https://staging-api.konto.io",
   clientId: 'YOUR_CLIENT_ID',
   scopes: ["users", "subscriptions", "transfers", "accounts"]
 });
 
-client.fetchTokenFromCredentials({ username, password })
+client.auth.fetchTokenFromCredentials({ username, password })
 	.then((tokenData) => {
 	  // do something with tokenData.accessToken
 	  // 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ If you'd rather handle the authentication UI flow in your app, and when your oAu
 const client = new Client({
   baseUrl: "https://staging-api.konto.io",
   clientId: 'YOUR_CLIENT_ID',
-  redirectUri: "",
-  state: "",
   scopes: ["users", "subscriptions", "transfers", "accounts"]
 });
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ await token.refresh((newToken) => { ... });
 </html>
 ```
 
+### Password-based authentication
+
+If you'd rather handle the authentication UI flow in your app, and when your oAuth2 client supports `grant_type: password`, you could request an access token in exchange for a user's credentials in one step:
+
+```javascript
+const client = new Client({
+  baseUrl: "https://staging-api.konto.io",
+  clientId: 'YOUR_CLIENT_ID',
+  redirectUri: "",
+  state: "",
+  scopes: ["users", "subscriptions", "transfers", "accounts"]
+});
+
+client.fetchTokenFromCredentials({ username, password })
+	.then((tokenData) => {
+	  // do something with tokenData.accessToken
+	  // 
+	  // or start using client to make authenticated requests
+	});
+```
+
 ### GraphQL queries
 
 #### Raw

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -143,6 +143,29 @@ export class Auth {
   };
 
   /**
+   * Fetches token from owner credentials.
+   * Only works for client IDs that support the 'password' grant type
+   *
+   * @param options     Username, password, and an optional set of scopes
+   *                    When given a set of scopes, they override the default list of
+   *                    scopes of `this` intance
+   *
+   * @returns           token object which might contain token(s), scope(s), token type and expiration time
+   */
+  public fetchTokenFromCredentials = async (options: {
+    username: string;
+    password: string;
+    scopes?: string[]
+  }) => {
+    const getTokenOpts = options.scopes && { scopes: options.scopes };
+    const token = await this.oauth2Client.owner.getToken(options.username, options.password, getTokenOpts);
+
+    this._token = token;
+
+    return token;
+  }
+
+  /**
    * Sets up  previously created token for all upcoming requests.
    *
    * @param accessToken   access token

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -157,7 +157,7 @@ export class Auth {
     password: string;
     scopes?: string[]
   }) => {
-    const getTokenOpts = options.scopes && { scopes: options.scopes };
+    const getTokenOpts = options.scopes ? { scopes: options.scopes } : {};
     const token = await this.oauth2Client.owner.getToken(options.username, options.password, getTokenOpts);
 
     this._token = token;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,9 +5,9 @@ export type ClientOpts = {
   clientId: string;
   clientSecret?: string;
   oauthClient?: ClientOAuth2;
-  redirectUri: string;
+  redirectUri?: string;
   scopes: string[];
-  state: string;
+  state?: string;
   verifier?: string;
 };
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -167,7 +167,6 @@ describe("Auth", () => {
 
       const stub = oauthClient.owner.getToken as sinon.SinonStub;
       const args = stub.getCall(0).args;
-      console.log(args);
       expect(args).to.deep.equal([ username, password, { scopes } ]);
     });
   });

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -125,6 +125,53 @@ describe("Auth", () => {
     });
   });
 
+  describe("client.auth.fetchTokenFromCredentials", () => {
+    const username = "user@kontist.com";
+    const password = "test1234";
+    const scopes = ["transfers"];
+
+    const tokenResponseData = {
+      access_token: "dummy-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+      token_type: "Bearer"
+    };
+
+    let oauthClient: ClientOAuth2;
+    let client: Client;
+
+    beforeEach(() => {
+      oauthClient = new ClientOAuth2({});
+
+      sinon.stub(oauthClient.owner, "getToken").callsFake(async () => {
+        return new ClientOAuth2.Token(oauthClient, tokenResponseData);
+      });
+
+      client = createClient({ oauthClient });
+    });
+
+    it("should call oauthClient.owner.getToken() with proper arguments", async () => {
+      await client.auth.fetchTokenFromCredentials({ username, password });
+
+      const stub = oauthClient.owner.getToken as sinon.SinonStub;
+      const args = stub.getCall(0).args;
+      expect(args).to.deep.equal([ username, password, {} ]);
+    });
+
+    it("should return token data", async () => {
+      const tokenData = await client.auth.fetchTokenFromCredentials({ username, password });
+
+      expect(tokenData.data).to.deep.equal(tokenResponseData);
+    });
+
+    it("should forward `scopes` to oauthClient.owner.getToken() when set", async () => {
+      await client.auth.fetchTokenFromCredentials({ username, password, scopes });
+
+      const stub = oauthClient.owner.getToken as sinon.SinonStub;
+      const args = stub.getCall(0).args;
+      console.log(args);
+      expect(args).to.deep.equal([ username, password, { scopes } ]);
+    });
+  });
+
   describe("when both code verifier and code secret are provided", () => {
     it("should throw an error", () => {
       let error;


### PR DESCRIPTION
Add a method on `client.auth` for fetching an oAuth2 token from a user's credentials, provided the oAuth client supports `grant_type: password`