### PR TITLE
GraphQL error handling

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -162,7 +162,7 @@ export class Auth {
   public fetchTokenFromCredentials = async (options: {
     username: string;
     password: string;
-    scopes?: string[]
+    scopes?: string[];
   }) => {
     const getTokenOpts = options.scopes ? { scopes: options.scopes } : {};
     const token = await this.oauth2Client.owner.getToken(options.username, options.password, getTokenOpts);

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,6 +1,7 @@
-type ErrorOpts = {
+export type ErrorOpts = {
   message?: string;
   status?: number;
+  type?: string;
 };
 
 export enum ErrorMessage {
@@ -9,7 +10,8 @@ export enum ErrorMessage {
   CHALLENGE_DENIED_ERROR = "Challenge denied",
   MFA_CONFIRMATION_CANCELED_ERROR = "MFA confirmation canceled",
   RENEW_TOKEN_ERROR = "Token renewal failed",
-  USER_UNAUTHORIZED_ERROR = "User unauthorized"
+  USER_UNAUTHORIZED_ERROR = "User unauthorized",
+  GRAPHQL_ERROR = "An error occurred while processing the GraphQL query"
 }
 
 export enum ErrorStatus {
@@ -18,12 +20,14 @@ export enum ErrorStatus {
 
 export class KontistSDKError extends Error {
   status?: number;
+  type?: string;
 
   constructor(opts: ErrorOpts = {}) {
     super(opts.message);
     Object.setPrototypeOf(this, KontistSDKError.prototype);
     this.name = this.constructor.name;
     this.status = opts.status;
+    this.type = opts.type;
   }
 }
 
@@ -79,6 +83,17 @@ export class RenewTokenError extends KontistSDKError {
       ...opts
     });
     Object.setPrototypeOf(this, RenewTokenError.prototype);
+    this.name = this.constructor.name;
+  }
+}
+
+export class GraphQLError extends KontistSDKError {
+  constructor(opts: ErrorOpts = {}) {
+    super({
+      message: ErrorMessage.GRAPHQL_ERROR,
+      ...opts
+    });
+    Object.setPrototypeOf(this, GraphQLError.prototype);
     this.name = this.constructor.name;
   }
 }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./authorizeSilently";
+export * from "./serializeGraphQLError";

--- a/lib/utils/serializeGraphQLError.ts
+++ b/lib/utils/serializeGraphQLError.ts
@@ -1,0 +1,36 @@
+import { ErrorOpts } from "../errors";
+
+type GraphQLAPIError = {
+  response?: {
+    errors?: [
+      {
+        message?: string;
+        extensions?: {
+          status?: number;
+          type?: string;
+        };
+      }
+    ];
+  };
+};
+
+export const serializeGraphQLError = (graphQLError: GraphQLAPIError): ErrorOpts => {
+  const errorOptions: ErrorOpts = {};
+
+  const errorDetails =
+    graphQLError.response &&
+    graphQLError.response.errors &&
+    graphQLError.response.errors[0];
+
+  if (errorDetails) {
+    errorOptions.message = errorDetails.message;
+
+    const { extensions } = errorDetails;
+    if (extensions) {
+      errorOptions.status = extensions.status;
+      errorOptions.type = extensions.type;
+    }
+  }
+
+  return errorOptions;
+};

--- a/lib/utils/serializeGraphQLError.ts
+++ b/lib/utils/serializeGraphQLError.ts
@@ -17,10 +17,7 @@ type GraphQLAPIError = {
 export const serializeGraphQLError = (graphQLError: GraphQLAPIError): ErrorOpts => {
   const errorOptions: ErrorOpts = {};
 
-  const errorDetails =
-    graphQLError.response &&
-    graphQLError.response.errors &&
-    graphQLError.response.errors[0];
+  const [errorDetails] = graphQLError.response?.errors ?? [];
 
   if (errorDetails) {
     errorOptions.message = errorDetails.message;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc && npx webpack",
-    "test": "mocha -r ts-node/register tests/**/*.spec.ts",
+    "test": "mocha -r ts-node/register --recursive 'tests/**/*.spec.ts'",
     "schema:generate": "graphql-codegen --config codegen.yml"
   },
   "dependencies": {

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { GraphQLClient as GQLClient } from "graphql-request";
+
+import { GraphQLError } from "../../lib/errors";
+
+import { createClient } from "../helpers";
+
+describe("Error handling", () => {
+  const setup = async (response: any) => {
+    const stub = sinon.stub(GQLClient.prototype, "rawRequest").throws(() => {
+      const error: any = new Error();
+      error.response = response;
+      return error;
+    });
+
+    const client = createClient();
+    client.auth.setToken("dummy-access-token");
+
+    let error;
+    try {
+      await client.graphQL.rawQuery(``);
+    } catch (err) {
+      error = err;
+    }
+
+    return {
+      error,
+      stub
+    };
+  };
+
+  describe("when a standard API error is returned", () => {
+    it("should throw a GraphQLError with proper message, status and type", async () => {
+      const message = "Some specific error message";
+      const status = 400;
+      const type = "http://www.iana.org/assignments/http-status-codes#400";
+      const response = {
+        errors: [
+          {
+            message,
+            locations: [{ line: 1, column: 42 }],
+            extensions: {
+              status,
+              type
+            }
+          }
+        ]
+      };
+
+      const { error, stub } = await setup(response);
+
+      expect(error).to.be.an.instanceof(GraphQLError);
+      expect(error.message).to.equal(message);
+      expect(error.status).to.equal(status);
+      expect(error.type).to.equal(type);
+
+      stub.restore();
+    });
+  });
+
+  describe("when an unexpected error was returned", () => {
+    it("should throw a GraphQLError with proper message", async () => {
+      const message = "Generic error message";
+      const response = {
+        errors: [
+          {
+            message,
+            locations: [{ line: 1, column: 42 }]
+          }
+        ]
+      };
+
+      const { error, stub } = await setup(response);
+
+      expect(error).to.be.an.instanceof(GraphQLError);
+      expect(error.message).to.equal(message);
+      expect(error.status).to.be.undefined;
+      expect(error.type).to.be.undefined;
+
+      stub.restore();
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses: https://github.com/kontist/figure-backend/issues/5854

Our GraphQL backend now appends error details when an API error is thrown in the `extensions` field (See GQL spec details about it here: https://graphql.github.io/graphql-spec/June2018/#sec-Errors).

It is a good opportunity to standardise the way we handle them in the SDK.

Here is how they are thrown after this PR:
<img width="774" alt="Screenshot 2019-11-07 at 17 38 43" src="https://user-images.githubusercontent.com/3253522/68463317-a9376900-020e-11ea-9007-53eeb1bb91c1.png">
