### PR TITLE
Raise error when state or redirectUri are missing

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -82,6 +82,13 @@ export class Auth {
       });
     }
 
+    if (verifier && (!state || !redirectUri)) {
+      throw new KontistSDKError({
+        message:
+          "If you are providing a 'verifier', you must also provide 'state' and 'redirectUri' options."
+      });
+    }
+
     this.oauth2Client =
       oauthClient ||
       new ClientOAuth2({

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -4,7 +4,7 @@ import * as moment from "moment";
 import ClientOAuth2 = require("client-oauth2");
 import { Client, Constants } from "../lib";
 import { MFA_CHALLENGE_PATH } from "../lib/auth";
-import { HttpMethod, ChallengeStatus } from "../lib/types";
+import { HttpMethod, ChallengeStatus, ClientOpts } from "../lib/types";
 import * as utils from "../lib/utils";
 
 describe("Auth", () => {
@@ -184,6 +184,25 @@ describe("Auth", () => {
       expect(error.message).to.equal(
         "You can provide only one parameter from ['verifier', 'clientSecret']."
       );
+    });
+  });
+
+  describe("when code verifier is provided but state or redirectUri are missing", () => {
+    const assertMissingOptionError = (option: keyof ClientOpts) => {
+      let error;
+      try {
+        client = createClient({ verifier, [option]: undefined });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.message).to.equal(
+        "If you are providing a 'verifier', you must also provide 'state' and 'redirectUri' options."
+      );
+    }
+    it("should throw an error", () => {
+      assertMissingOptionError("state");
+      assertMissingOptionError("redirectUri")
     });
   });
 


### PR DESCRIPTION
In this PR https://github.com/kontist/js-sdk/pull/23 we changed client constructor `state` and `redirectUri` fields to be optional, which is fine, but when users specify `verifier` they will use PKCE which requires both `state` and `redirectUri` to be present.

Does it make sense to warn the user when they are not provided in that case?