### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Introduce refresh method when doing browser auth via PKCE #19
+- Expose `Schema` in "kontist" namespace
+- Improved handling of GraphQL error messages
+
+### Changed
+- Rename package to "kontist" instead of "@kontist/client"
+- Upgrade to TypeScript 3.7 and remove lodash #22


### PR DESCRIPTION
Please have a look if that format makes sense, based on https://keepachangelog.com/en/1.0.0/.
On release we would just move the items from `[Unreleased]` into sth like `## [0.0.18] 2019-11-08`