### PR TITLE
Export errors and IResultPageInterface

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,7 @@
 import { Client } from "./client";
 import * as Constants from "./constants";
 import * as Schema from "./graphql/schema";
+import { IResultPageInterface } from "./graphql/interfaces";
+import * as errors from "./errors";
 
-export { Client, Constants, Schema };
+export { Client, Constants, Schema, IResultPageInterface, errors };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import { Client } from "./client";
 import * as Constants from "./constants";
 import * as Schema from "./graphql/schema";
-import { IResultPageInterface } from "./graphql/interfaces";
-import * as errors from "./errors";
+import * as Interfaces from "./graphql/interfaces";
+import * as Errors from "./errors";
 
-export { Client, Constants, Schema, IResultPageInterface, errors };
+export { Client, Constants, Schema, Interfaces, Errors };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import { Client } from "./client";
 import * as Constants from "./constants";
 import * as Schema from "./graphql/schema";
 import * as Interfaces from "./graphql/interfaces";
+import * as Types from "./graphql/types";
 import * as Errors from "./errors";
 
-export { Client, Constants, Schema, Interfaces, Errors };
+export { Client, Constants, Schema, Interfaces, Types, Errors };


### PR DESCRIPTION
Not sure if we should export `IResultPageInterface` directly or expose a `types` module...