### PR TITLE
Add transaction subscription logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Introduce a method to subscribe to new transactions (`models.transaction.subscribe`)
 
 ## [0.20.0] - 2019-11-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -178,19 +178,24 @@ const transactions = await client.models.transaction.fetch();
 To subscribe to new transactions:
 
 ```typescript
-const handler = transaction => {
+const onNext = transaction => {
   // do something with the transaction
 }
 
-client.models.transaction.subscribe(handler);
+const onError = error => {
+  // do something with the error
+}
+
+client.models.transaction.subscribe(onNext, onError);
 ```
 
-Whenever a new transaction is created, the `handler` function will be called.
+Whenever a new transaction is created, the `onNext` function will be called.
+Whenever an error occurs with the subscription, the `onError` function will be called.
 
-The `subscribe` method returns an `unsubscribe` function to be called when you want to unsubscribe to new transactions:
+The `subscribe` method returns a `Subscription` object with an `unsubscribe` method to be called when you want to unsubscribe to new transactions:
 
 ```typescript
-const unsubscribe = client.models.transaction.subscribe(handler);
+const { unsubscribe } = client.models.transaction.subscribe(handler);
 // ...
 unsubscribe();
 // after this point, handler will no longer be called when new transactions are received

--- a/README.md
+++ b/README.md
@@ -175,6 +175,27 @@ To fetch up to 50 latest transactions:
 const transactions = await client.models.transaction.fetch();
 ```
 
+To subscribe to new transactions:
+
+```typescript
+const handler = transaction => {
+  // do something with the transaction
+}
+
+client.models.transaction.subscribe(handler);
+```
+
+Whenever a new transaction is created, the `handler` function will be called.
+
+The `subscribe` method returns an `unsubscribe` function to be called when you want to unsubscribe to new transactions:
+
+```typescript
+const unsubscribe = client.models.transaction.subscribe(handler);
+// ...
+unsubscribe();
+// after this point, handler will no longer be called when new transactions are received
+```
+
 #### Transfers
 
 To create and confirm a transfer / timed order / standing order:

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,15 +1,20 @@
 import { Auth } from "./auth";
 import { GraphQLClient } from "./graphql/client";
 import { ClientOpts } from "./types";
-import { KONTIST_API_BASE_URL } from "./constants";
+import { KONTIST_API_BASE_URL, KONTIST_SUBSCRIPTION_API_BASE_URL } from "./constants";
 import { getModels } from "./graphql";
 
 export class Client {
   constructor(
     opts: ClientOpts,
     baseUrl = opts.baseUrl || KONTIST_API_BASE_URL,
+    baseSubscriptionUrl = opts.baseSubscriptionUrl || KONTIST_SUBSCRIPTION_API_BASE_URL,
     public auth = new Auth(baseUrl, opts),
-    public graphQL = new GraphQLClient(`${baseUrl}/api/graphql`, auth),
+    public graphQL = new GraphQLClient({
+      auth,
+      endpoint: `${baseUrl}/api/graphql`,
+      subscriptionEndpoint: `${baseSubscriptionUrl}/api/graphql`
+    }),
     public models = getModels(graphQL)
   ) {}
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,2 @@
 export const KONTIST_API_BASE_URL = "https://api.kontist.com";
+export const KONTIST_SUBSCRIPTION_API_BASE_URL = "wss://api.kontist.com";

--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -19,10 +19,6 @@ type Subscriptions = {
   };
 };
 
-type ConnectionParams = {
-  Authorization: string;
-};
-
 export class GraphQLClient {
   private auth: Auth;
   private client: GQLClient;

--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -157,7 +157,7 @@ export class GraphQLClient {
    * Unsubscribe to a topic
    */
   public unsubscribe = (subscriptionId: number): (() => void) => () => {
-    this.subscriptions[subscriptionId].unsubscribe();
+    this.subscriptions[subscriptionId]?.unsubscribe();
     delete this.subscriptions[subscriptionId];
 
     if (Object.keys(this.subscriptions).length === 0) {

--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -1,19 +1,42 @@
 import { GraphQLClient as GQLClient } from "graphql-request";
+import { SubscriptionClient } from "subscriptions-transport-ws";
 import { Variables } from "graphql-request/dist/src/types";
+import * as ws from "ws";
 
 import { Auth } from "../auth";
 import { RawQueryResponse } from "./types";
 import { serializeGraphQLError } from "../utils";
 import { GraphQLError, UserUnauthorizedError } from "../errors";
+import { GraphQLClientOpts } from "../types";
+
+const WebSocket = typeof window === "undefined" ? ws : window.WebSocket;
+
+type Subscriptions = {
+  [key: string]: Function;
+};
 
 export class GraphQLClient {
-  private client: GQLClient;
   private auth: Auth;
+  private client: GQLClient;
+  private subscriptionClient: SubscriptionClient;
+  private subscriptions: Subscriptions = {};
 
-  constructor(endpoint: string, auth: Auth) {
-    this.client = new GQLClient(endpoint);
+  constructor({ auth, endpoint, subscriptionEndpoint }: GraphQLClientOpts) {
     this.auth = auth;
+    this.client = new GQLClient(endpoint);
+    this.subscriptionClient = new SubscriptionClient(
+      subscriptionEndpoint,
+      {
+        lazy: true,
+        reconnect: true,
+        connectionParams: () => ({
+          Authorization: `Bearer ${this.auth.tokenManager.token?.accessToken}`
+        })
+      },
+      WebSocket
+    );
   }
+
   /**
    * Send a raw GraphQL request and return its response.
    */
@@ -36,5 +59,35 @@ export class GraphQLClient {
     } catch (error) {
       throw new GraphQLError(serializeGraphQLError(error));
     }
+  };
+
+  /**
+   * Subscribe to a topic and call the handler when new data is received
+   */
+  public subscribe = (query: string, topic: string, handler: Function) => {
+    const subscription = this.subscriptionClient.request({
+      query
+    });
+
+    const { unsubscribe } = subscription.subscribe({
+      next(response) {
+        handler({
+          type: topic,
+          data: response.data?.[topic]
+        });
+      }
+    });
+
+    this.subscriptions[topic] = unsubscribe;
+  };
+
+  /**
+   * Unsubscribe to a topic
+   */
+  public unsubscribe = (topic: string) => {
+    if (this.subscriptions[topic]) {
+      this.subscriptions[topic]();
+    }
+    delete this.subscriptions[topic];
   };
 }

--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -80,11 +80,15 @@ export class GraphQLClient {
   };
 
   /**
-   * Handle disconnection by refreshing access token and resubscribing
-   * all previously active subscriptions
+   * Handle disconnection:
+   *
+   * 1. Refresh access token
+   * 2. Destroy existing subscription client
+   * 3. Resubscribe all previously active subscriptions
    */
   private handleDisconnection = async (): Promise<void> => {
     await this.auth.tokenManager.refresh();
+    this.subscriptionClient = null;
     Object.values(this.subscriptions).forEach(subscription => {
       this.subscribe(
         subscription.query,

--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -62,13 +62,6 @@ export class GraphQLClient {
   };
 
   /**
-   * Return subscription client connection params
-   */
-  private getConnectionParams = (): ConnectionParams => ({
-    Authorization: `Bearer ${this.auth.tokenManager.token?.accessToken}`
-  });
-
-  /**
    * Create a subscription client
    */
   private createSubscriptionClient = (): SubscriptionClient => {
@@ -82,7 +75,9 @@ export class GraphQLClient {
       this.subscriptionEndpoint,
       {
         lazy: true,
-        connectionParams: this.getConnectionParams
+        connectionParams: {
+          Authorization: `Bearer ${this.auth.tokenManager.token.accessToken}`
+        }
       },
       WebSocket
     );

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -7,7 +7,7 @@ import { IterableModel } from "./iterableModel";
 import {
   FetchOptions,
   SubscriptionType,
-  Unsubscribe
+  Subscription
 } from "./types";
 import { ResultPage } from "./resultPage";
 
@@ -83,7 +83,7 @@ export class Transaction extends IterableModel<TransactionEntry> {
   subscribe(
     onNext: (event: Transaction) => any,
     onError?: (error: Error) => any
-  ): Unsubscribe {
+  ): Subscription {
     return this.client.subscribe({
       query: NEW_TRANSACTION_SUBSCRIPTION,
       type: SubscriptionType.newTransaction,

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -6,7 +6,7 @@ import {
 import { IterableModel } from "./iterableModel";
 import {
   FetchOptions,
-  SubscriptionEvent,
+  TransactionSubscriptionEvent,
   SubscriptionType,
   Unsubscribe
 } from "./types";
@@ -81,7 +81,7 @@ export class Transaction extends IterableModel<TransactionEntry> {
     return new ResultPage(this, transactions, pageInfo);
   }
 
-  subscribe(handler: (event: SubscriptionEvent) => any): Unsubscribe {
+  subscribe(handler: (event: TransactionSubscriptionEvent) => any): Unsubscribe {
     return this.client.subscribe(
       NEW_TRANSACTION_SUBSCRIPTION,
       SubscriptionType.newTransaction,

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -6,7 +6,6 @@ import {
 import { IterableModel } from "./iterableModel";
 import {
   FetchOptions,
-  TransactionSubscriptionEvent,
   SubscriptionType,
   Unsubscribe
 } from "./types";
@@ -81,11 +80,15 @@ export class Transaction extends IterableModel<TransactionEntry> {
     return new ResultPage(this, transactions, pageInfo);
   }
 
-  subscribe(handler: (event: TransactionSubscriptionEvent) => any): Unsubscribe {
-    return this.client.subscribe(
-      NEW_TRANSACTION_SUBSCRIPTION,
-      SubscriptionType.newTransaction,
-      handler
-    );
+  subscribe(
+    onNext: (event: Transaction) => any,
+    onError?: (error: Error) => any
+  ): Unsubscribe {
+    return this.client.subscribe({
+      query: NEW_TRANSACTION_SUBSCRIPTION,
+      type: SubscriptionType.newTransaction,
+      onNext,
+      onError
+    });
   }
 }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -81,7 +81,7 @@ export class Transaction extends IterableModel<TransactionEntry> {
   }
 
   subscribe(
-    onNext: (event: Transaction) => any,
+    onNext: (event: TransactionEntry) => any,
     onError?: (error: Error) => any
   ): Subscription {
     return this.client.subscribe({

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -74,9 +74,14 @@ export class Transaction extends IterableModel<TransactionEntry> {
   async fetch(args?: FetchOptions): Promise<ResultPage<TransactionEntry>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSACTIONS, args);
 
-    const transactions = (result?.viewer?.mainAccount?.transactions?.edges ?? []).map((edge: TransactionsConnectionEdge) => edge.node);
+    const transactions = (
+      result?.viewer?.mainAccount?.transactions?.edges ?? []
+    ).map((edge: TransactionsConnectionEdge) => edge.node);
 
-    const pageInfo = result?.viewer?.mainAccount?.transactions?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false};
+    const pageInfo = result?.viewer?.mainAccount?.transactions?.pageInfo ?? {
+      hasNextPage: false,
+      hasPreviousPage: false
+    };
     return new ResultPage(this, transactions, pageInfo);
   }
 

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -4,8 +4,35 @@ import {
   Transaction as TransactionEntry
 } from "./schema";
 import { IterableModel } from "./iterableModel";
-import { FetchOptions } from "./types";
+import {
+  FetchOptions,
+  SubscriptionListeners,
+  SubscriptionEvent,
+  SubscriptionType
+} from "./types";
 import { ResultPage } from "./resultPage";
+
+const TRANSACTION_FIELDS = `
+  id
+  amount
+  name
+  iban
+  type
+  bookingDate
+  valutaDate
+  originalAmount
+  foreignCurrency
+  e2eId
+  mandateNumber
+  paymentMethod
+  category
+  userSelectedBookingDate
+  purpose
+  documentNumber
+  documentPreviewUrl
+  documentDownloadUrl
+  documentType
+`;
 
 const FETCH_TRANSACTIONS = `query fetchTransactions ($first: Int, $last: Int, $after: String, $before: String) {
   viewer {
@@ -13,25 +40,7 @@ const FETCH_TRANSACTIONS = `query fetchTransactions ($first: Int, $last: Int, $a
       transactions(first: $first, last: $last, after: $after, before: $before) {
         edges {
           node {
-              id
-              amount
-              name
-              iban
-              type
-              bookingDate
-              valutaDate
-              originalAmount
-              foreignCurrency
-              e2eId
-              mandateNumber
-              paymentMethod
-              category
-              userSelectedBookingDate
-              purpose
-              documentNumber
-              documentPreviewUrl
-              documentDownloadUrl
-              documentType
+            ${TRANSACTION_FIELDS}
           }
         }
         pageInfo {
@@ -45,7 +54,17 @@ const FETCH_TRANSACTIONS = `query fetchTransactions ($first: Int, $last: Int, $a
   }
 }`;
 
+const SUBSCRIPTION_QUERIES = {
+  newTransaction: `subscription {
+    newTransaction {
+      ${TRANSACTION_FIELDS}
+    }
+  }`
+};
+
 export class Transaction extends IterableModel<TransactionEntry> {
+  private listeners: SubscriptionListeners = {};
+
   /**
    * Fetches first 50 transactions which match the query
    *
@@ -59,5 +78,55 @@ export class Transaction extends IterableModel<TransactionEntry> {
 
     const pageInfo = result?.viewer?.mainAccount?.transactions?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false};
     return new ResultPage(this, transactions, pageInfo);
+  }
+
+  /**
+   * Add a listener to a GraphQL subscription topic
+   *
+   * @param type     the subscription topic to listen to
+   * @param handler  the handler to be called when new data is received
+   */
+  public addEventListener(type: SubscriptionType, handler: Function) {
+    if (!this.listeners[type] && SUBSCRIPTION_QUERIES[type]) {
+      this.client.subscribe(
+        SUBSCRIPTION_QUERIES[type],
+        type,
+        this.dispatchEvent.bind(this)
+      );
+      this.listeners[type] = [];
+    }
+    (this.listeners?.[type] ?? []).push(handler);
+  }
+
+  /**
+   * Remove a listener to a GraphQL subscription topic
+   *
+   * @param type     the subscription topic to remove a listener from
+   * @param handler  the handler to be removed
+   */
+  public removeEventListener(type: SubscriptionType, handler: Function) {
+    if (!this.listeners[type]) {
+      return;
+    }
+
+    this.listeners[type] = this.listeners[type].filter(
+      listener => listener !== handler
+    );
+
+    if (this.listeners[type].length === 0) {
+      this.client.unsubscribe(type);
+      delete this.listeners[type];
+    }
+  }
+
+  /**
+   * Dispatch an event to all the listener of its type
+   *
+   * @param event  the subscription event to dispatch
+   */
+  private dispatchEvent(event: SubscriptionEvent) {
+    (this.listeners?.[event.type] ?? []).forEach(listener => {
+      listener(event);
+    });
   }
 }

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,10 +1,28 @@
-import { Query, Mutation } from "./schema";
+import { Query, Mutation, Transaction } from "./schema";
 
 export type FetchOptions = {
   first?: number;
   last?: number;
   before?: string | null;
   after?: string | null;
+};
+
+export enum SubscriptionType {
+  newTransaction = "newTransaction"
+}
+
+
+export type SubscriptionListeners = {
+  [key: string]: Function[];
+};
+
+export type SubscriptionEvent = {
+  type: SubscriptionType;
+  data: SubscriptionResponse;
+};
+
+export type SubscriptionResponse = {
+  newTransaction: Transaction;
 };
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,4 +1,5 @@
 import { Query, Mutation, Transaction } from "./schema";
+import { FormatedError } from "subscriptions-transport-ws/dist/client";
 
 export type FetchOptions = {
   first?: number;
@@ -11,18 +12,15 @@ export enum SubscriptionType {
   newTransaction = "newTransaction"
 }
 
-
-export type SubscriptionListeners = {
-  [key: string]: Function[];
-};
-
 export type SubscriptionEvent = {
-  type: SubscriptionType;
-  data: SubscriptionResponse;
+  data?: SubscriptionResponse;
+  error?: Error;
 };
 
 export type SubscriptionResponse = {
   newTransaction: Transaction;
 };
+
+export type Unsubscribe = () => void;
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,4 +1,4 @@
-import { Query, Mutation, Transaction } from "./schema";
+import { Query, Mutation } from "./schema";
 
 export type FetchOptions = {
   first?: number;
@@ -11,6 +11,8 @@ export enum SubscriptionType {
   newTransaction = "newTransaction"
 }
 
-export type Unsubscribe = () => void;
+export type Subscription = {
+  unsubscribe: () => void;
+};
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -11,14 +11,6 @@ export enum SubscriptionType {
   newTransaction = "newTransaction"
 }
 
-export type SubscriptionEvent = {
-  data?: any;
-  error?: Error;
-}
-export type TransactionSubscriptionEvent = SubscriptionEvent & {
-  data?: Transaction;
-};
-
 export type Unsubscribe = () => void;
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,5 +1,4 @@
 import { Query, Mutation, Transaction } from "./schema";
-import { FormatedError } from "subscriptions-transport-ws/dist/client";
 
 export type FetchOptions = {
   first?: number;
@@ -13,12 +12,11 @@ export enum SubscriptionType {
 }
 
 export type SubscriptionEvent = {
-  data?: SubscriptionResponse;
+  data?: any;
   error?: Error;
-};
-
-export type SubscriptionResponse = {
-  newTransaction: Transaction;
+}
+export type TransactionSubscriptionEvent = SubscriptionEvent & {
+  data?: Transaction;
 };
 
 export type Unsubscribe = () => void;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,5 @@
 import * as ClientOAuth2 from "client-oauth2";
+import { Auth } from "./auth";
 
 export enum HttpMethod {
   GET = "GET",
@@ -10,8 +11,15 @@ export enum HttpMethod {
   DELETE = "DELETE"
 }
 
+export type GraphQLClientOpts = {
+  endpoint: string;
+  subscriptionEndpoint: string;
+  auth: Auth;
+};
+
 export type ClientOpts = {
   baseUrl?: string;
+  baseSubscriptionUrl?: string;
   clientId: string;
   clientSecret?: string;
   oauthClient?: ClientOAuth2;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1890,6 +1890,15 @@
       "integrity": "sha1-YPpDXOJL/VuhB7jSqAeWrq86j0U=",
       "dev": true
     },
+    "@types/ws": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
+      "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -2490,8 +2499,12 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+<<<<<<< HEAD
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+=======
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+>>>>>>> Add base logic for handling subscriptions
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2583,6 +2596,11 @@
         "lodash": "^4.2.0",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -4034,6 +4052,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
       "version": "3.0.0",
@@ -6235,8 +6258,7 @@
     "iterall": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
-      "dev": true
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "js-sha256": {
       "version": "0.9.0",
@@ -9459,6 +9481,28 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "subscriptions-transport-ws": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -9478,8 +9522,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -10522,11 +10565,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
       "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
+<<<<<<< HEAD
       "dev": true,
+=======
+>>>>>>> Add base logic for handling subscriptions
       "requires": {
         "async-limiter": "^1.0.0"
       }
     },
+<<<<<<< HEAD
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -10539,6 +10586,8 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+=======
+>>>>>>> Add base logic for handling subscriptions
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2499,12 +2499,7 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-<<<<<<< HEAD
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
-=======
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
->>>>>>> Add base logic for handling subscriptions
     },
     "asynckit": {
       "version": "0.4.0",
@@ -10565,15 +10560,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
       "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-<<<<<<< HEAD
-      "dev": true,
-=======
->>>>>>> Add base logic for handling subscriptions
       "requires": {
         "async-limiter": "^1.0.0"
       }
     },
-<<<<<<< HEAD
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -10586,8 +10576,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-=======
->>>>>>> Add base logic for handling subscriptions
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "client-oauth2": "^4.2.5",
     "graphql-request": "^1.8.2",
     "js-sha256": "^0.9.0",
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "subscriptions-transport-ws": "^0.9.16",
+    "ws": "^7.2.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.8.3",
@@ -27,6 +29,7 @@
     "@types/jsdom": "^12.2.4",
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.0",
+    "@types/ws": "^6.0.3",
     "chai": "^4.2.0",
     "graphql": "^14.5.8",
     "jsdom": "^15.2.1",

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -10,14 +10,14 @@ describe("Client", () => {
         const redirectUri = "https://localhost:3000/auth/callback";
         const scopes = ["transactions"];
         const state = "25843739712322056";
-  
+
         const client = new Client({
           clientId,
           redirectUri,
           scopes,
           state
         });
-  
+
         expect(client).to.exist;
       });
       it("should be able to create a client with all parameters", () => {
@@ -45,6 +45,7 @@ describe("Client", () => {
         const client = new Client(
           opts,
           "http://localhost:3000/api/graphql",
+          "ws://localhost:3000/api/graphql",
           auth,
           graphQL,
           models,

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -59,7 +59,7 @@ describe("Error handling", () => {
     });
   });
 
-  describe("when an unexpected error was returned", () => {
+  describe("when an unexpected error is returned", () => {
     it("should throw a GraphQLError with proper message", async () => {
       const message = "Generic error message";
       const response = {

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -369,12 +369,12 @@ describe("unsubscribe", () => {
           unsubscribe: () => {}
         }
       };
-    })
+    });
 
     it("should not throw any error", () => {
       client.graphQL.unsubscribe(42)();
-    })
-  })
+    });
+  });
 });
 
 describe("handleDisconnection", () => {
@@ -502,9 +502,9 @@ describe("createSubscriptionClient", () => {
         `${KONTIST_SUBSCRIPTION_API_BASE_URL}/api/graphql`
       );
       expect(options.lazy).to.equal(true);
-      expect(options.connectionParams).to.equal(
-        client.graphQL.getConnectionParams
-      );
+      expect(options.connectionParams).to.deep.equal({
+        Authorization: "Bearer dummy-token"
+      });
       expect(websocket).to.equal(ws);
       expect(subscriptionClient).to.equal(fakeSubscriptionClient);
     });
@@ -532,32 +532,4 @@ describe("createSubscriptionClient", () => {
       });
     });
   });
-});
-
-describe("getConnectionParams", () => {
-  let client: any;
-  const accessToken = "dummy-access-token-1234";
-
-  before(() => {
-    client = createClient();
-    client.auth.tokenManager.setToken(accessToken);
-  });
-
-  it("should return an object with proper Authorization property", () => {
-    expect(client.graphQL.getConnectionParams()).to.deep.equal({
-      Authorization: `Bearer ${accessToken}`
-    });
-  });
-
-  describe("when access token is missing", () => {
-    before(() => {
-      client.auth.tokenManager._token = undefined;
-    })
-
-    it("should still return proper connection params", () => {
-      expect(client.graphQL.getConnectionParams()).to.deep.equal({
-        Authorization: "Bearer undefined"
-      });
-    })
-  })
 });

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -548,4 +548,16 @@ describe("getConnectionParams", () => {
       Authorization: `Bearer ${accessToken}`
     });
   });
+
+  describe("when access token is missing", () => {
+    before(() => {
+      client.auth.tokenManager._token = undefined;
+    })
+
+    it("should still return proper connection params", () => {
+      expect(client.graphQL.getConnectionParams()).to.deep.equal({
+        Authorization: "Bearer undefined"
+      });
+    })
+  })
 });

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -1,84 +1,290 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { GraphQLClient as GQLClient } from "graphql-request";
+import { SubscriptionType } from "../../lib/graphql/types";
 
 import { GraphQLError } from "../../lib/errors";
 
 import { createClient } from "../helpers";
 
-describe("Error handling", () => {
-  const setup = async (response: any) => {
-    const stub = sinon.stub(GQLClient.prototype, "rawRequest").throws(() => {
-      const error: any = new Error();
-      error.response = response;
-      return error;
+describe("rawQuery", () => {
+  describe("Error handling", () => {
+    const setup = async (response: any) => {
+      const stub = sinon.stub(GQLClient.prototype, "rawRequest").throws(() => {
+        const error: any = new Error();
+        error.response = response;
+        return error;
+      });
+
+      const client = createClient();
+      client.auth.tokenManager.setToken("dummy-access-token");
+
+      let error;
+      try {
+        await client.graphQL.rawQuery(``);
+      } catch (err) {
+        error = err;
+      }
+
+      return {
+        error,
+        stub
+      };
+    };
+
+    describe("when a standard API error is returned", () => {
+      it("should throw a GraphQLError with proper message, status and type", async () => {
+        const message = "Some specific error message";
+        const status = 400;
+        const type = "http://www.iana.org/assignments/http-status-codes#400";
+        const response = {
+          errors: [
+            {
+              message,
+              locations: [{ line: 1, column: 42 }],
+              extensions: {
+                status,
+                type
+              }
+            }
+          ]
+        };
+
+        const { error, stub } = await setup(response);
+
+        expect(error).to.be.an.instanceof(GraphQLError);
+        expect(error.message).to.equal(message);
+        expect(error.status).to.equal(status);
+        expect(error.type).to.equal(type);
+
+        stub.restore();
+      });
     });
 
-    const client = createClient();
-    client.auth.tokenManager.setToken("dummy-access-token");
+    describe("when an unexpected error is returned", () => {
+      it("should throw a GraphQLError with proper message", async () => {
+        const message = "Generic error message";
+        const response = {
+          errors: [
+            {
+              message,
+              locations: [{ line: 1, column: 42 }]
+            }
+          ]
+        };
 
-    let error;
-    try {
-      await client.graphQL.rawQuery(``);
-    } catch (err) {
-      error = err;
+        const { error, stub } = await setup(response);
+
+        expect(error).to.be.an.instanceof(GraphQLError);
+        expect(error.message).to.equal(message);
+        expect(error.status).to.be.undefined;
+        expect(error.type).to.be.undefined;
+
+        stub.restore();
+      });
+    });
+  });
+});
+
+describe("subscribe", () => {
+  const observableMock = {
+    nextHandlers: [] as any,
+    errorHandlers: [] as any,
+    triggerNext(response: any) {
+      this.nextHandlers.forEach((handler: any) => {
+        handler(response);
+      });
+    },
+    triggerError(err: any) {
+      this.errorHandlers.forEach((handler: any) => {
+        handler(err);
+      });
     }
-
-    return {
-      error,
-      stub
-    };
   };
 
-  describe("when a standard API error is returned", () => {
-    it("should throw a GraphQLError with proper message, status and type", async () => {
-      const message = "Some specific error message";
-      const status = 400;
-      const type = "http://www.iana.org/assignments/http-status-codes#400";
-      const response = {
-        errors: [
-          {
-            message,
-            locations: [{ line: 1, column: 42 }],
-            extensions: {
-              status,
-              type
-            }
-          }
-        ]
+  const subscribeStub = sinon
+    .stub()
+    .callsFake(({ next, error }: { next: any; error: any }) => {
+      observableMock.nextHandlers.push(next as any);
+      observableMock.errorHandlers.push(error as any);
+      return {
+        unsubscribe: () => {
+          observableMock.nextHandlers = observableMock.nextHandlers.filter(
+            (handler: any) => handler !== next
+          );
+          observableMock.errorHandlers = observableMock.errorHandlers.filter(
+            (handler: any) => handler !== error
+          );
+        }
       };
+    });
+  const subscriptionClientMock = {
+    onDisconnected: sinon.spy(),
+    close: sinon.spy(),
+    request: () => ({
+      subscribe: subscribeStub
+    })
+  };
+  const subscriptionQuery = `subscription someSubscription {}`;
+  const client = createClient();
+  const firstSubscriptionHandlerStub = sinon.stub();
+  const secondSubscriptionHandlerStub = sinon.stub();
+  let createSubscriptionClientStub: any;
+  let firstSubscriptionResult: any;
+  let secondSubscriptionResult: any;
 
-      const { error, stub } = await setup(response);
+  before(() => {
+    createSubscriptionClientStub = sinon
+      .stub(client.graphQL as any, "createSubscriptionClient")
+      .returns(subscriptionClientMock);
+  });
 
-      expect(error).to.be.an.instanceof(GraphQLError);
-      expect(error.message).to.equal(message);
-      expect(error.status).to.equal(status);
-      expect(error.type).to.equal(type);
+  after(() => {
+    createSubscriptionClientStub.restore();
+  });
 
-      stub.restore();
+  describe("when adding the first subscription", () => {
+    before(() => {
+      firstSubscriptionResult = client.graphQL.subscribe(
+        subscriptionQuery,
+        SubscriptionType.newTransaction,
+        firstSubscriptionHandlerStub
+      );
+    });
+
+    it("should create a subscription client", () => {
+      expect(createSubscriptionClientStub.callCount).to.equal(1);
+    });
+
+    it("should setup a disconnection handler", () => {
+      expect(subscriptionClientMock.onDisconnected.callCount).to.equal(1);
+      expect(subscriptionClientMock.onDisconnected.getCall(0).args[0]).to.equal(
+        client.graphQL["handleDisconnection"]
+      );
+    });
+
+    it("should add a subscription to its state", () => {
+      const subscription = client.graphQL["subscriptions"][1];
+      expect(subscription.id).to.equal(1);
+      expect(subscription.query).to.equal(subscriptionQuery);
+      expect(subscription.type).to.equal(SubscriptionType.newTransaction);
+      expect(subscription.handler).to.equal(firstSubscriptionHandlerStub);
+      expect(subscription.unsubscribe).to.be.a("function");
     });
   });
 
-  describe("when an unexpected error is returned", () => {
-    it("should throw a GraphQLError with proper message", async () => {
-      const message = "Generic error message";
-      const response = {
-        errors: [
-          {
-            message,
-            locations: [{ line: 1, column: 42 }]
-          }
-        ]
-      };
+  describe("when adding a second subscription", () => {
+    before(() => {
+      createSubscriptionClientStub.resetHistory();
 
-      const { error, stub } = await setup(response);
+      secondSubscriptionResult = client.graphQL.subscribe(
+        subscriptionQuery,
+        SubscriptionType.newTransaction,
+        secondSubscriptionHandlerStub
+      );
+    });
 
-      expect(error).to.be.an.instanceof(GraphQLError);
-      expect(error.message).to.equal(message);
-      expect(error.status).to.be.undefined;
-      expect(error.type).to.be.undefined;
+    it("should NOT create a subscription client", () => {
+      expect(createSubscriptionClientStub.callCount).to.equal(0);
+    });
 
-      stub.restore();
+    it("should add a second subscription to its state", () => {
+      const subscription = client.graphQL["subscriptions"][2];
+      expect(Object.keys(client.graphQL["subscriptions"]).length).to.equal(2);
+      expect(subscription.id).to.equal(2);
+      expect(subscription.query).to.equal(subscriptionQuery);
+      expect(subscription.type).to.equal(SubscriptionType.newTransaction);
+      expect(subscription.handler).to.equal(secondSubscriptionHandlerStub);
+      expect(subscription.unsubscribe).to.be.a("function");
     });
   });
+
+  describe("when receiving new data", () => {
+    it("should call the subscribed handlers", () => {
+      expect(firstSubscriptionHandlerStub.callCount).to.equal(0);
+      expect(secondSubscriptionHandlerStub.callCount).to.equal(0);
+
+      const dummyData = {
+        data: { [SubscriptionType.newTransaction]: "some-data" }
+      };
+      observableMock.triggerNext(dummyData);
+
+      expect(firstSubscriptionHandlerStub.callCount).to.equal(1);
+      const { data, error } = firstSubscriptionHandlerStub.getCall(0).args[0];
+      expect(data).to.equal("some-data");
+      expect(error).to.be.an("undefined");
+      expect(secondSubscriptionHandlerStub.callCount).to.equal(1);
+      const {
+        data: secondHandlerData,
+        error: secondHandlerError
+      } = secondSubscriptionHandlerStub.getCall(0).args[0];
+      expect(secondHandlerData).to.equal("some-data");
+      expect(secondHandlerError).to.be.an("undefined");
+    });
+  });
+
+  describe("when receiving an error", () => {
+    it("should call the subscribed handlers", () => {
+      const dummyError = new Error("Unauthorized");
+      observableMock.triggerError(dummyError);
+
+      expect(firstSubscriptionHandlerStub.callCount).to.equal(2);
+      const { data, error } = firstSubscriptionHandlerStub.getCall(1).args[0];
+      expect(data).to.be.a("null");
+      expect(error).to.equal(dummyError);
+      expect(secondSubscriptionHandlerStub.callCount).to.equal(2);
+      const {
+        data: secondHandlerData,
+        error: secondHandlerError
+      } = secondSubscriptionHandlerStub.getCall(1).args[0];
+      expect(secondHandlerData).to.be.a("null");
+      expect(secondHandlerError).to.equal(dummyError);
+    });
+  });
+
+  describe("when unsubscribing", () => {
+    before(() => {
+      firstSubscriptionResult();
+    });
+
+    it("should no longer call the unsubscribed handlers", () => {
+
+      observableMock.triggerNext({ data: { some: "data" } });
+
+      expect(firstSubscriptionHandlerStub.callCount).to.equal(2);
+      expect(secondSubscriptionHandlerStub.callCount).to.equal(3);
+
+      observableMock.triggerError(new Error());
+
+      expect(firstSubscriptionHandlerStub.callCount).to.equal(2);
+      expect(secondSubscriptionHandlerStub.callCount).to.equal(4);
+    });
+
+    it("should remove the corresponding subscription from its state", () => {
+      const subscriptions = client.graphQL["subscriptions"];
+      expect(Object.keys(subscriptions).length).to.equal(1);
+
+      expect(subscriptions[1]).to.be.a("undefined");
+      expect(subscriptions[2]).to.exist;
+    });
+  });
+
+  describe("when the last subscription is unsubscribed", () => {
+    it("should close the websocket and remove the subscription client", () => {
+      expect(subscriptionClientMock.close.callCount).to.equal(0);
+
+      secondSubscriptionResult();
+
+      expect(Object.keys(client.graphQL["subscriptions"]).length).to.equal(0);
+
+      expect(subscriptionClientMock.close.callCount).to.equal(1);
+      expect(client.graphQL["subscriptionClient"]).to.be.a("null");
+
+      observableMock.triggerNext({ data: { some: "data" } });
+      observableMock.triggerError(new Error());
+
+      expect(firstSubscriptionHandlerStub.callCount).to.equal(2);
+      expect(secondSubscriptionHandlerStub.callCount).to.equal(4);
+    });
+  })
 });

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -81,10 +81,10 @@ describe("Transaction", () => {
       const result = client.models.transaction.subscribe(callback);
 
       expect(subscribeStub.callCount).to.equal(1);
-      const [query, type, handler] = subscribeStub.getCall(0).args;
+      const { query, type, onNext } = subscribeStub.getCall(0).args[0];
       expect(query).to.equal(NEW_TRANSACTION_SUBSCRIPTION);
       expect(type).to.equal(SubscriptionType.newTransaction);
-      expect(handler).to.equal(callback);
+      expect(onNext).to.equal(callback);
       expect(result).to.equal(unsubscribe);
     });
   });

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -76,7 +76,7 @@ describe("Transaction", () => {
       const callback = () => {};
       const subscribeStub = sinon
         .stub(client.graphQL, "subscribe")
-        .returns(unsubscribe);
+        .returns({ unsubscribe });
 
       const result = client.models.transaction.subscribe(callback);
 
@@ -85,7 +85,7 @@ describe("Transaction", () => {
       expect(query).to.equal(NEW_TRANSACTION_SUBSCRIPTION);
       expect(type).to.equal(SubscriptionType.newTransaction);
       expect(onNext).to.equal(callback);
-      expect(result).to.equal(unsubscribe);
+      expect(result).to.deep.equal({ unsubscribe });
     });
   });
 });

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { RawQueryResponse } from "../../lib/graphql/types";
+import { RawQueryResponse, SubscriptionType } from "../../lib/graphql/types";
 import { Transaction } from "../../lib/graphql/schema";
 import { createClient, createTransaction } from "../helpers";
+import { NEW_TRANSACTION_SUBSCRIPTION } from "../../lib/graphql/transaction";
 
 describe("Transaction", () => {
   describe("iterator", () => {
@@ -65,6 +66,26 @@ describe("Transaction", () => {
       }
 
       expect(transactions).to.deep.equal([firstTransaction, secondTransaction]);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("should call the corresponding graphQL client method to subscribe", () => {
+      const client = createClient();
+      const unsubscribe = () => {};
+      const callback = () => {};
+      const subscribeStub = sinon
+        .stub(client.graphQL, "subscribe")
+        .returns(unsubscribe);
+
+      const result = client.models.transaction.subscribe(callback);
+
+      expect(subscribeStub.callCount).to.equal(1);
+      const [query, type, handler] = subscribeStub.getCall(0).args;
+      expect(query).to.equal(NEW_TRANSACTION_SUBSCRIPTION);
+      expect(type).to.equal(SubscriptionType.newTransaction);
+      expect(handler).to.equal(callback);
+      expect(result).to.equal(unsubscribe);
     });
   });
 });


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-backend/issues/5892

In this PR we are adding a `client.models.transaction.subscribe()` method which uses gql subscriptions to notify SDK users when new transactions are received (see the readme changes for explanations about the usage)

Notes:
* In the end we went with an "observable" style approach instead of "event listeners", it seemed a bit more reasonable during the implementation
* we are attempting to reconnect automatically on behalf of the user when the websocket connection is closed