### PR TITLE
Add basic cli to fetch token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log*
 !.vscode/launch.json
 coverage/
 .nyc_output/
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ yarn-error.log*
 .DS_Store
 .vscode/
 !.vscode/launch.json
+.env

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// split command and arguments
+let [,, cmd, ...args] = process.argv;
+const fs = require("fs");
+
+// some basic traversal attack protection
+cmd = cmd.replace(/[^a-z\-]/gi, '');
+
+// if a file with the name of the command exists run it
+if (fs.existsSync(`${__dirname}/${cmd}.js`)) {
+    require('dotenv').config();
+    require(`${__dirname}/${cmd}`).exec(args)
+        .catch(e => console.error(e));
+} else {
+    console.error(`Unknown command: '${cmd}'`);
+    process.exit(127);
+}

--- a/cli/token.js
+++ b/cli/token.js
@@ -1,0 +1,47 @@
+async function exec(args) {
+
+    // show help and exit
+    if (args[0] === "--help") {
+        return showHelp();
+    }
+
+    // create client and login with password grant type
+    const { Client } = require("../dist/index");
+    const client = new Client({
+        baseUrl: process.env.KONTIST_BASE_URL || "https://api.kontist.com",
+        clientId: process.env.KONTIST_CLIENT_ID,
+        clientSecret: process.env.KONTIST_CLIENT_SECRET,
+        scopes: (process.env.KONTIST_CLIENT_SCOPES || "accounts").split(","),
+    });
+    const token = await client.auth.tokenManager.fetchTokenFromCredentials({
+        username: process.env.KONTIST_USERNAME,
+        password: process.env.KONTIST_PASSWORD,
+    });
+
+    // send token to stdout
+    console.log(token.accessToken);
+};
+
+function showHelp() {
+    console.log(`
+Returns a new access token.
+
+Usage:
+  kontist token [--help]
+
+Options:
+  --help        Show this help.
+
+Please provide this environment variables (or put them into a .env file):
+  KONTIST_BASE_URL (optional, defaults to https://api.kontist.com)
+  KONTIST_CLIENT_ID
+  KONTIST_CLIENT_SECRET
+  KONTIST_CLIENT_SCOPES (optional, defaults to "accounts"; Use comma separated string)
+  KONTIST_USERNAME
+  KONTIST_PASSWORD
+
+The client needs to have the "password" grant type enabled.
+    `);
+}
+
+module.exports = { exec };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2934,6 +2934,12 @@
         "no-case": "^2.2.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "abab": "^2.0.2",
     "client-oauth2": "^4.2.5",
     "graphql-request": "^1.8.2",
-    "js-sha256": "^0.9.0"
+    "js-sha256": "^0.9.0",
+    "dotenv": "^8.2.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.8.1",
@@ -27,7 +28,6 @@
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.0",
     "chai": "^4.2.0",
-    "dotenv": "^8.2.0",
     "graphql": "^14.5.8",
     "jsdom": "^15.2.1",
     "mocha": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.0",
     "chai": "^4.2.0",
+    "dotenv": "^8.2.0",
     "graphql": "^14.5.8",
     "jsdom": "^15.2.1",
     "mocha": "^6.2.1",
@@ -37,5 +38,8 @@
     "typescript": "^3.7.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.9"
+  },
+  "bin": {
+    "kontist": "./cli/index.js"
   }
 }


### PR DESCRIPTION
Some scripts we are going to create need a simple way to build a token via cli.
This PR introduces a small script to fetch a token based on environment variables.

One can test it with:
`npm link` to make the `kontist token` command available (use `npm unlink` for cleanup later)

Either export some environment variables or create a `.env` file like this:
```
KONTIST_BASE_URL=http://localhost:3000
KONTIST_CLIENT_ID=59EB8F37-40B6-...-...-...
KONTIST_CLIENT_SECRET=...
KONTIST_USERNAME=...
KONTIST_PASSWORD=...
```

Goal is to allow running this script by just calling `npx kontist token` (once published)