### PR TITLE
Add support for transfer fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce methods for fetching transfers (`models.transfer.fetch`, `models.transfer.fetchAll`)
 
+### Changed
+- *Breaking*: changed transaction async iterator from `models.transaction` to `models.transaction.fetchAll`.
+
 ## [0.20.0] - 2019-11-18
 ### Added
 - Introduce methods for transfers cancellation (`cancelTransfer` and `confirmCancelTransfer`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Introduce methods for fetching transfers (`models.transfer.fetch`, `models.transfer.fetchAll`)
 
 ## [0.20.0] - 2019-11-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ An example to show how to fetch all user transactions
 
 ```typescript
 let transactions = [];
-for await (const transaction of client.models.transaction) {
+for await (const transaction of client.models.transaction.fetchAll()) {
   transactions = transactions.concat(transaction);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ const result = await client.graphQL.rawQuery(query);
 
 #### Transactions
 
-An example to show how to fetch all user transactions
+An example to show how to fetch all user transactions:
 
 ```typescript
 let transactions = [];
@@ -226,7 +226,7 @@ const result = await client.models.transfer.confirmMany(
 );
 ```
 
-An example to show how to fetch all user transfers of a given type
+An example to show how to fetch all user transfers of a given type:
 
 ```typescript
 let transfers = [];

--- a/README.md
+++ b/README.md
@@ -226,6 +226,25 @@ const result = await client.models.transfer.confirmMany(
 );
 ```
 
+An example to show how to fetch all user transfers of a given type
+
+```typescript
+let transfers = [];
+for await (const transfer of client.models.transfer.fetchAll({
+  type: Schema.TransferType.SepaTransfer
+})) {
+  transfers = transfers.concat(transfer);
+}
+```
+
+To fetch up to 50 latest transfers of a given type:
+
+```typescript
+const transfers = await client.models.transfer.fetch({
+  type: Schema.TransferType.TimedOrder
+});
+```
+
 ## MFA (Multi-Factor Authentication)
 
 Accessing Kontist banking APIs require Multi-Factor Authentication (MFA).

--- a/lib/graphql/interfaces.ts
+++ b/lib/graphql/interfaces.ts
@@ -1,4 +1,3 @@
-import { FetchOptions } from "./types";
 import { PageInfo } from "./schema";
 
 export interface IResultPageInterface<T> {
@@ -8,6 +7,6 @@ export interface IResultPageInterface<T> {
   previousPage?: () => Promise<IResultPageInterface<T>>;
 }
 
-export interface IFetch<T> {
-  fetch(args?: FetchOptions): Promise<IResultPageInterface<T>>;
+export interface IFetch<ModelType, FetchOptionsType> {
+  fetch(args?: FetchOptionsType): Promise<IResultPageInterface<ModelType>>;
 }

--- a/lib/graphql/iterableModel.ts
+++ b/lib/graphql/iterableModel.ts
@@ -2,10 +2,13 @@ import { ResultPage } from "./resultPage";
 import { Model } from "./model";
 import { FetchOptions } from "./types";
 
-export abstract class IterableModel<T> extends Model<T> {
-  createAsyncIterator(args?: FetchOptions) {
+export abstract class IterableModel<
+  ModelType,
+  FetchOptionsType = FetchOptions
+> extends Model<ModelType, FetchOptionsType> {
+  createAsyncIterator(args?: FetchOptionsType) {
     const fetch = this.fetch.bind(this);
-    let lastResult!: ResultPage<T>;
+    let lastResult!: ResultPage<ModelType, FetchOptionsType>;
 
     return {
       next: async () => {
@@ -18,7 +21,7 @@ export abstract class IterableModel<T> extends Model<T> {
           lastResult = await fetch({
             ...args,
             after: lastResult.pageInfo.endCursor
-          });
+          } as FetchOptionsType);
         }
 
         // return the items as long as there are some
@@ -35,7 +38,7 @@ export abstract class IterableModel<T> extends Model<T> {
     };
   }
 
-  fetchAll(args?: FetchOptions) {
+  fetchAll(args?: FetchOptionsType) {
     const asyncIterator = this.createAsyncIterator(args);
     return {
       [Symbol.asyncIterator]() {

--- a/lib/graphql/iterableModel.ts
+++ b/lib/graphql/iterableModel.ts
@@ -35,10 +35,6 @@ export abstract class IterableModel<T> extends Model<T> {
     };
   }
 
-  [Symbol.asyncIterator]() {
-    return this.createAsyncIterator();
-  }
-
   fetchAll(args?: FetchOptions) {
     const asyncIterator = this.createAsyncIterator(args);
     return {

--- a/lib/graphql/iterableModel.ts
+++ b/lib/graphql/iterableModel.ts
@@ -6,7 +6,7 @@ export abstract class IterableModel<
   ModelType,
   FetchOptionsType = FetchOptions
 > extends Model<ModelType, FetchOptionsType> {
-  createAsyncIterator(args?: FetchOptionsType) {
+  createAsyncIterator(args: FetchOptionsType) {
     const fetch = this.fetch.bind(this);
     let lastResult!: ResultPage<ModelType, FetchOptionsType>;
 
@@ -21,7 +21,7 @@ export abstract class IterableModel<
           lastResult = await fetch({
             ...args,
             after: lastResult.pageInfo.endCursor
-          } as FetchOptionsType);
+          });
         }
 
         // return the items as long as there are some
@@ -38,7 +38,7 @@ export abstract class IterableModel<
     };
   }
 
-  fetchAll(args?: FetchOptionsType) {
+  fetchAll(args: FetchOptionsType) {
     const asyncIterator = this.createAsyncIterator(args);
     return {
       [Symbol.asyncIterator]() {

--- a/lib/graphql/model.ts
+++ b/lib/graphql/model.ts
@@ -1,14 +1,17 @@
 import { GraphQLClient } from "./client";
 import { ResultPage } from "./resultPage";
-import { FetchOptions } from "./types";
 import { IFetch } from "./interfaces";
+import { FetchOptions } from "./types";
 
-export abstract class Model<T> implements IFetch<T> {
+export abstract class Model<ModelType, FetchOptionsType = FetchOptions>
+  implements IFetch<ModelType, FetchOptionsType> {
   protected client: GraphQLClient;
 
   constructor(graphqlClient: GraphQLClient) {
     this.client = graphqlClient;
   }
 
-  abstract async fetch(args?: FetchOptions): Promise<ResultPage<T>>;
+  abstract async fetch(
+    args?: FetchOptionsType
+  ): Promise<ResultPage<ModelType, FetchOptionsType>>;
 }

--- a/lib/graphql/resultPage.ts
+++ b/lib/graphql/resultPage.ts
@@ -2,28 +2,32 @@ import { PageInfo } from "./schema";
 import { IFetch } from "./interfaces";
 import { FetchOptions } from "./types";
 
-export class ResultPage<T> {
-  items: Array<T>;
+export class ResultPage<ModelType, FetchOptionsType = FetchOptions> {
+  items: Array<ModelType>;
   pageInfo: PageInfo;
-  nextPage?: () => Promise<ResultPage<T>>;
-  previousPage?: () => Promise<ResultPage<T>>;
+  nextPage?: () => Promise<ResultPage<ModelType, FetchOptionsType>>;
+  previousPage?: () => Promise<ResultPage<ModelType, FetchOptionsType>>;
 
   constructor(
-    model: IFetch<T>,
-    items: Array<T>,
+    model: IFetch<ModelType, FetchOptionsType>,
+    items: Array<ModelType>,
     pageInfo: PageInfo,
-    args: FetchOptions = {}
+    args?: FetchOptionsType
   ) {
     this.items = items;
     this.pageInfo = pageInfo;
 
     if (pageInfo.hasNextPage) {
-      this.nextPage = () => model.fetch({ ...args, after: pageInfo.endCursor });
+      this.nextPage = () =>
+        model.fetch({ ...args, after: pageInfo.endCursor } as FetchOptionsType);
     }
 
     if (pageInfo.hasPreviousPage) {
       this.previousPage = () =>
-        model.fetch({ ...args, before: pageInfo.startCursor });
+        model.fetch({
+          ...args,
+          before: pageInfo.startCursor
+        } as FetchOptionsType);
     }
   }
 }

--- a/lib/graphql/resultPage.ts
+++ b/lib/graphql/resultPage.ts
@@ -12,14 +12,14 @@ export class ResultPage<ModelType, FetchOptionsType = FetchOptions> {
     model: IFetch<ModelType, FetchOptionsType>,
     items: Array<ModelType>,
     pageInfo: PageInfo,
-    args?: FetchOptionsType
+    args: FetchOptionsType
   ) {
     this.items = items;
     this.pageInfo = pageInfo;
 
     if (pageInfo.hasNextPage) {
       this.nextPage = () =>
-        model.fetch({ ...args, after: pageInfo.endCursor } as FetchOptionsType);
+        model.fetch({ ...args, after: pageInfo.endCursor });
     }
 
     if (pageInfo.hasPreviousPage) {
@@ -27,7 +27,7 @@ export class ResultPage<ModelType, FetchOptionsType = FetchOptions> {
         model.fetch({
           ...args,
           before: pageInfo.startCursor
-        } as FetchOptionsType);
+        });
     }
   }
 }

--- a/lib/graphql/resultPage.ts
+++ b/lib/graphql/resultPage.ts
@@ -1,5 +1,6 @@
 import { PageInfo } from "./schema";
 import { IFetch } from "./interfaces";
+import { FetchOptions } from "./types";
 
 export class ResultPage<T> {
   items: Array<T>;
@@ -7,16 +8,22 @@ export class ResultPage<T> {
   nextPage?: () => Promise<ResultPage<T>>;
   previousPage?: () => Promise<ResultPage<T>>;
 
-  constructor(model: IFetch<T>, items: Array<T>, pageInfo: PageInfo) {
+  constructor(
+    model: IFetch<T>,
+    items: Array<T>,
+    pageInfo: PageInfo,
+    args: FetchOptions = {}
+  ) {
     this.items = items;
     this.pageInfo = pageInfo;
 
     if (pageInfo.hasNextPage) {
-      this.nextPage = () => model.fetch({ after: pageInfo.endCursor });
+      this.nextPage = () => model.fetch({ ...args, after: pageInfo.endCursor });
     }
 
     if (pageInfo.hasPreviousPage) {
-      this.previousPage = () => model.fetch({ before: pageInfo.startCursor });
+      this.previousPage = () =>
+        model.fetch({ ...args, before: pageInfo.startCursor });
     }
   }
 }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -60,4 +60,11 @@ export class Transaction extends IterableModel<TransactionModel> {
     const pageInfo = result?.viewer?.mainAccount?.transactions?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false};
     return new ResultPage(this, transactions, pageInfo, args);
   }
+
+  /**
+   * @inheritdoc
+   */
+  fetchAll(args?: FetchOptions) {
+    return super.fetchAll(args ?? {});
+  }
 }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -58,6 +58,6 @@ export class Transaction extends IterableModel<TransactionEntry> {
     const transactions = (result?.viewer?.mainAccount?.transactions?.edges ?? []).map((edge: TransactionsConnectionEdge) => edge.node);
 
     const pageInfo = result?.viewer?.mainAccount?.transactions?.pageInfo ?? { hasNextPage: false, hasPreviousPage: false};
-    return new ResultPage(this, transactions, pageInfo);
+    return new ResultPage(this, transactions, pageInfo, args);
   }
 }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -1,11 +1,11 @@
 import {
   Query,
   TransactionsConnectionEdge,
-  Transaction as TransactionEntry
+  Transaction as TransactionModel
 } from "./schema";
 import { IterableModel } from "./iterableModel";
-import { FetchOptions } from "./types";
 import { ResultPage } from "./resultPage";
+import { FetchOptions } from "./types";
 
 const FETCH_TRANSACTIONS = `query fetchTransactions ($first: Int, $last: Int, $after: String, $before: String) {
   viewer {
@@ -45,14 +45,14 @@ const FETCH_TRANSACTIONS = `query fetchTransactions ($first: Int, $last: Int, $a
   }
 }`;
 
-export class Transaction extends IterableModel<TransactionEntry> {
+export class Transaction extends IterableModel<TransactionModel> {
   /**
    * Fetches first 50 transactions which match the query
    *
    * @param args  query parameters
    * @returns     result page
    */
-  async fetch(args?: FetchOptions): Promise<ResultPage<TransactionEntry>> {
+  async fetch(args?: FetchOptions): Promise<ResultPage<TransactionModel>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSACTIONS, args);
 
     const transactions = (result?.viewer?.mainAccount?.transactions?.edges ?? []).map((edge: TransactionsConnectionEdge) => edge.node);

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -247,6 +247,6 @@ export class Transfer extends IterableModel<CreateTransferInput> {
       hasNextPage: false,
       hasPreviousPage: false
     };
-    return new ResultPage(this, transfers, pageInfo);
+    return new ResultPage(this, transfers, pageInfo, args);
   }
 }

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -7,7 +7,7 @@ import {
   TransfersConnectionEdge,
   ConfirmationRequestOrTransfer
 } from "./schema";
-import { FetchOptions } from "./types";
+import { TransferFetchOptions } from "./types";
 import { ResultPage } from "./resultPage";
 import { IterableModel } from "./iterableModel";
 
@@ -212,7 +212,15 @@ export class Transfer extends IterableModel<CreateTransferInput> {
     return result.confirmCancelTransfer;
   }
 
-  async fetch(args: FetchOptions): Promise<ResultPage<TransferEntry>> {
+  createAsyncIterator(args: TransferFetchOptions) {
+    return super.createAsyncIterator(args);
+  }
+
+  fetchAll(args: TransferFetchOptions) {
+    return super.fetchAll(args);
+  }
+
+  async fetch(args: TransferFetchOptions): Promise<ResultPage<TransferEntry>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSFERS, args);
 
     const transfers = (result?.viewer?.mainAccount?.transfers?.edges ?? []).map(

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -1,13 +1,29 @@
 import {
+  Query,
   CreateTransferInput,
   Transfer as TransferEntry,
   BatchTransfer,
   TransferType,
+  TransfersConnectionEdge,
   ConfirmationRequestOrTransfer
 } from "./schema";
-import { Model } from "./model";
 import { FetchOptions } from "./types";
 import { ResultPage } from "./resultPage";
+import { IterableModel } from "./iterableModel";
+
+const TRANSFER_FIELDS = `
+  id
+  recipient
+  iban
+  amount
+  status
+  executeAt
+  lastExecutionDate
+  purpose
+  e2eId
+  reoccurrence
+  nextOccurrence
+`;
 
 const CREATE_TRANSFER = `mutation createTransfer($transfer: CreateTransferInput!) {
   createTransfer(transfer: $transfer) {
@@ -23,17 +39,7 @@ const CONFIRM_TRANSFER = `mutation confirmTransfer(
     confirmationId: $confirmationId
     authorizationToken: $authorizationToken
   ) {
-    id
-    recipient
-    iban
-    amount
-    status
-    executeAt
-    lastExecutionDate
-    purpose
-    e2eId
-    reoccurrence
-    nextOccurrence
+    ${TRANSFER_FIELDS}
   }
 }`;
 
@@ -72,17 +78,7 @@ const CANCEL_TRANSFER = `mutation cancelTransfer($type: TransferType!, $id: Stri
     }
 
     ... on Transfer {
-      id
-      recipient
-      iban
-      amount
-      status
-      executeAt
-      lastExecutionDate
-      purpose
-      e2eId
-      reoccurrence
-      nextOccurrence
+      ${TRANSFER_FIELDS}
     }
   }
 }`;
@@ -97,21 +93,31 @@ const CONFIRM_CANCEL_TRANSFER = `mutation confirmCancelTransfer(
     confirmationId: $confirmationId
     authorizationToken: $authorizationToken
   ) {
-    id
-    recipient
-    iban
-    amount
-    status
-    executeAt
-    lastExecutionDate
-    purpose
-    e2eId
-    reoccurrence
-    nextOccurrence
+    ${TRANSFER_FIELDS}
   }
 }`;
 
-export class Transfer extends Model<CreateTransferInput> {
+const FETCH_TRANSFERS = `query fetchTransfers ($type: TransferType!, $first: Int, $last: Int, $after: String, $before: String) {
+  viewer {
+    mainAccount {
+      transfers(type: $type, first: $first, last: $last, after: $after, before: $before) {
+        edges {
+          node {
+            ${TRANSFER_FIELDS}
+          }
+        }
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+      }
+    }
+  }
+}`;
+
+export class Transfer extends IterableModel<CreateTransferInput> {
   /**
    * Creates single wire transfer / timed order / standing order
    *
@@ -177,7 +183,10 @@ export class Transfer extends Model<CreateTransferInput> {
    * @param id        transfer id
    * @returns         confirmation id used to confirm the cancellation or transfer if confirmation is not needed
    */
-  async cancelTransfer(type: TransferType,id: string): Promise<ConfirmationRequestOrTransfer> {
+  async cancelTransfer(
+    type: TransferType,
+    id: string
+  ): Promise<ConfirmationRequestOrTransfer> {
     const result = await this.client.rawQuery(CANCEL_TRANSFER, { type, id });
     return result.cancelTransfer;
   }
@@ -203,7 +212,17 @@ export class Transfer extends Model<CreateTransferInput> {
     return result.confirmCancelTransfer;
   }
 
-  async fetch(args?: FetchOptions): Promise<ResultPage<TransferEntry>> {
-    throw new Error("not implemented yet");
+  async fetch(args: FetchOptions): Promise<ResultPage<TransferEntry>> {
+    const result: Query = await this.client.rawQuery(FETCH_TRANSFERS, args);
+
+    const transfers = (result?.viewer?.mainAccount?.transfers?.edges ?? []).map(
+      (edge: TransfersConnectionEdge) => edge.node
+    );
+
+    const pageInfo = result?.viewer?.mainAccount?.transfers?.pageInfo ?? {
+      hasNextPage: false,
+      hasPreviousPage: false
+    };
+    return new ResultPage(this, transfers, pageInfo);
   }
 }

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -212,14 +212,30 @@ export class Transfer extends IterableModel<CreateTransferInput> {
     return result.confirmCancelTransfer;
   }
 
+  /**
+   * @override specify query parameter arguments for transfers
+   *
+   * @param args query parameters
+   */
   createAsyncIterator(args: TransferFetchOptions) {
     return super.createAsyncIterator(args);
   }
 
+  /**
+   * @override specify query parameter arguments for transfers
+   *
+   * @param args query parameters
+   */
   fetchAll(args: TransferFetchOptions) {
     return super.fetchAll(args);
   }
 
+  /**
+   * Fetches first 50 transfers of provided type which match the query
+   *
+   * @param args  query parameters
+   * @returns     result page
+   */
   async fetch(args: TransferFetchOptions): Promise<ResultPage<TransferEntry>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSFERS, args);
 

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -1,7 +1,7 @@
 import {
   Query,
   CreateTransferInput,
-  Transfer as TransferEntry,
+  Transfer as TransferModel,
   BatchTransfer,
   TransferType,
   TransfersConnectionEdge,
@@ -117,7 +117,10 @@ const FETCH_TRANSFERS = `query fetchTransfers ($type: TransferType!, $first: Int
   }
 }`;
 
-export class Transfer extends IterableModel<CreateTransferInput> {
+export class Transfer extends IterableModel<
+  TransferModel,
+  TransferFetchOptions
+> {
   /**
    * Creates single wire transfer / timed order / standing order
    *
@@ -139,7 +142,7 @@ export class Transfer extends IterableModel<CreateTransferInput> {
   async confirmOne(
     confirmationId: string,
     authorizationToken: string
-  ): Promise<TransferEntry> {
+  ): Promise<TransferModel> {
     const result = await this.client.rawQuery(CONFIRM_TRANSFER, {
       confirmationId,
       authorizationToken
@@ -203,7 +206,7 @@ export class Transfer extends IterableModel<CreateTransferInput> {
     type: TransferType,
     confirmationId: string,
     authorizationToken: string
-  ): Promise<TransferEntry> {
+  ): Promise<TransferModel> {
     const result = await this.client.rawQuery(CONFIRM_CANCEL_TRANSFER, {
       type,
       confirmationId,
@@ -213,30 +216,14 @@ export class Transfer extends IterableModel<CreateTransferInput> {
   }
 
   /**
-   * @override specify query parameter arguments for transfers
-   *
-   * @param args query parameters
-   */
-  createAsyncIterator(args: TransferFetchOptions) {
-    return super.createAsyncIterator(args);
-  }
-
-  /**
-   * @override specify query parameter arguments for transfers
-   *
-   * @param args query parameters
-   */
-  fetchAll(args: TransferFetchOptions) {
-    return super.fetchAll(args);
-  }
-
-  /**
    * Fetches first 50 transfers of provided type which match the query
    *
    * @param args  query parameters
    * @returns     result page
    */
-  async fetch(args: TransferFetchOptions): Promise<ResultPage<TransferEntry>> {
+  async fetch(
+    args: TransferFetchOptions
+  ): Promise<ResultPage<TransferModel, TransferFetchOptions>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSFERS, args);
 
     const transfers = (result?.viewer?.mainAccount?.transfers?.edges ?? []).map(

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,4 +1,9 @@
-import { Query, Mutation, TransferType } from "./schema";
+import {
+  Query,
+  Mutation,
+  TransferType,
+  TransfersConnectionFilter
+} from "./schema";
 
 export type FetchOptions = {
   first?: number;
@@ -9,6 +14,7 @@ export type FetchOptions = {
 
 export type TransferFetchOptions = {
   type: TransferType;
+  where?: TransfersConnectionFilter;
 } & FetchOptions;
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,14 +1,11 @@
-import { Query, Mutation } from "./schema";
+import { Query, Mutation, TransferType } from "./schema";
 
 export type FetchOptions = {
   first?: number;
   last?: number;
   before?: string | null;
   after?: string | null;
+  type?: TransferType;
 };
-
-export type TransferFetchOptions = {
-  type: string;
-} & FetchOptions;
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -5,7 +5,10 @@ export type FetchOptions = {
   last?: number;
   before?: string | null;
   after?: string | null;
-  type?: TransferType;
 };
+
+export type TransferFetchOptions = {
+  type: TransferType;
+} & FetchOptions;
 
 export type RawQueryResponse = Query & Mutation;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -7,4 +7,8 @@ export type FetchOptions = {
   after?: string | null;
 };
 
+export type TransferFetchOptions = {
+  type: string;
+} & FetchOptions;
+
 export type RawQueryResponse = Query & Mutation;

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -64,11 +64,11 @@ describe("Transaction", () => {
       };
 
       stub.onSecondCall().resolves(secondResponse as RawQueryResponse);
-    })
+    });
 
     afterEach(() => {
       stub.restore();
-    })
+    });
 
     it("can iterate on all user transactions using the root iterator", async () => {
       let transactions: Array<Transaction> = [];

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -86,7 +86,7 @@ describe("Transaction", () => {
 
     it("can iterate on all user transactions using the fetchAll iterator", async () => {
       let transactions: Array<Transaction> = [];
-      for await (const transaction of client.models.transaction.fetchAll()) {
+      for await (const transaction of client.models.transaction.fetchAll({})) {
         transactions = transactions.concat(transaction as Transaction);
       }
 

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -70,6 +70,18 @@ describe("Transaction", () => {
       stub.restore();
     });
 
+    it("can fetch next page using the nextPage method", async () => {
+      const firstPage = await client.models.transaction.fetch({
+        first: 1
+      });
+
+      expect(typeof firstPage.nextPage).to.equal("function");
+      expect(firstPage.items).to.deep.equal([firstTransaction]);
+
+      const secondPage = firstPage.nextPage && (await firstPage.nextPage());
+      expect(secondPage?.items).to.deep.equal([secondTransaction]);
+    });
+
     it("can iterate on all user transactions using the root iterator", async () => {
       let transactions: Array<Transaction> = [];
       for await (const transaction of client.models.transaction) {

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -86,7 +86,7 @@ describe("Transaction", () => {
 
     it("can iterate on all user transactions using the fetchAll iterator", async () => {
       let transactions: Array<Transaction> = [];
-      for await (const transaction of client.models.transaction.fetchAll({})) {
+      for await (const transaction of client.models.transaction.fetchAll({after})) {
         transactions = transactions.concat(transaction as Transaction);
       }
 

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -86,7 +86,7 @@ describe("Transaction", () => {
 
     it("can iterate on all user transactions using the fetchAll iterator", async () => {
       let transactions: Array<Transaction> = [];
-      for await (const transaction of client.models.transaction.fetchAll({after})) {
+      for await (const transaction of client.models.transaction.fetchAll()) {
         transactions = transactions.concat(transaction as Transaction);
       }
 

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -84,15 +84,6 @@ describe("Transaction", () => {
       expect(secondPage?.items).to.deep.equal([secondTransaction]);
     });
 
-    it("can iterate on all user transactions using the root iterator", async () => {
-      let transactions: Array<Transaction> = [];
-      for await (const transaction of client.models.transaction) {
-        transactions = transactions.concat(transaction as Transaction);
-      }
-
-      expect(transactions).to.deep.equal([firstTransaction, secondTransaction]);
-    });
-
     it("can iterate on all user transactions using the fetchAll iterator", async () => {
       let transactions: Array<Transaction> = [];
       for await (const transaction of client.models.transaction.fetchAll()) {

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -132,6 +132,19 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.onSecondCall().resolves(secondResponse);
     });
 
+    it("can fetch next page using the nextPage method", async () => {
+      const firstPage = await transferInstance.fetch({
+        first: 1,
+        type: TransferType.SepaTransfer
+      });
+
+      expect(typeof firstPage.nextPage).to.equal("function");
+      expect(firstPage.items).to.deep.equal([firstTransfer]);
+
+      const secondPage = firstPage.nextPage && (await firstPage.nextPage());
+      expect(secondPage?.items).to.deep.equal([secondTransfer]);
+    });
+
     it("can iterate on all user transfers using the fetchAll iterator", async () => {
       let transfers: Array<Transfer> = [];
       for await (const transfer of transferInstance.fetchAll({

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,9 @@
-import { TransactionProjectionType, Transaction } from "../lib/graphql/schema";
+import {
+  TransactionProjectionType,
+  Transaction,
+  Transfer,
+  TransferStatus
+} from "../lib/graphql/schema";
 import { Client } from "../lib";
 
 export const clientId = "26990216-e340-4f54-b5a5-df9baacc0440";
@@ -25,5 +30,24 @@ export const createTransaction = (): Transaction => {
     fees: [],
     bookingDate: new Date(),
     paymentMethod: "card"
+  };
+};
+
+export const createTransfer = (
+  override: Record<string, any> = {}
+): Transfer => {
+  return {
+    id: Math.random.toString(),
+    recipient: "John Doe",
+    iban: "DE32110101001000000029",
+    amount: parseInt((Math.random() * 100).toString()),
+    status: TransferStatus.Confirmed,
+    executeAt: null,
+    lastExecutionDate: null,
+    purpose: "some transfer purpose",
+    e2eId: "some-e2e-id",
+    reoccurrence: null,
+    nextOccurrence: null,
+    ...override
   };
 };


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-backend/issues/5931

We want to add a way to fetch transfers of all types, keeping a consistent API with the existing transaction methods.


**Open questions / thoughts:**

* Should we keep the `for await (const transaction of client.models.transaction)` iterator on the base `iterableModel`, even if it is not usable for transfers? should we deprecate it? should we completely remove it (I am almost sure the webapp doesn't use it yet)? Removing it would obviously simplify the logic a little bit
* Is it fine to override the base `IterableModel` methods in `transfer` model to provide the correct argument type? I don't know if there is a better typescript way to do this
 
**Implementation details:**

Specifying the type for transfers is mandatory (we can only fetch transfers of a given type)

The current interface to fetch all transactions (`asyncIterator` property on the class) does not allow to pass any argument.

A possibility would have been to split the transfers models into 3 separate models, but I thought it was probably better to stick to the one model and change the existing interface a little bit.

So I implemented a method returning an asyncIterator:
```
  let transactions = [];
  for await (const transaction of client.models.transaction.fetchAll()) {
    transactions = transaction.concat(transaction);
  }
```

whereas before it was 
```
  let transactions = [];
  for await (const transaction of client.models.transaction) {
    transactions = transaction.concat(transaction);
  }
```

In order to avoid introducing any breaking changes, I updated the `IterableModel` to expose both.

For transfers, usage will be the same, but specifying `type` will be mandatory:
```
  let transfers = [];
  for await (const transfer of client.models.transfer.fetchAll({
    type: "SEPA_TRANSFER"
  })) {
    transfers = transfers.concat(transfer);
  }
```

Specifying type is also mandatory on the `fetch` method of transfer model:
```
const transfers = await client.models.transfer.fetch({
  type: "TIMED_ORDER"
});
```

