### PR TITLE
Add enum for transaction category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Type for `Transaction.category` changed from `string` to `TransactionCategory` enum. This is a *breaking* change.
 
 ## [0.20.0] - 2019-11-18
 ### Added

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -624,7 +624,7 @@ export type Transaction = {
   directDebitFees: Array<DirectDebitFee>,
   name?: Maybe<Scalars['String']>,
   paymentMethod: Scalars['String'],
-  category?: Maybe<Scalars['String']>,
+  category?: Maybe<TransactionCategory>,
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>,
   purpose?: Maybe<Scalars['String']>,
   documentNumber?: Maybe<Scalars['String']>,
@@ -634,6 +634,18 @@ export type Transaction = {
   foreignCurrency?: Maybe<Scalars['String']>,
   originalAmount?: Maybe<Scalars['Int']>,
 };
+
+export enum TransactionCategory {
+  Private = 'private',
+  Vat = 'vat',
+  Vat0 = 'vat0',
+  Vat7 = 'vat7',
+  Vat19 = 'vat19',
+  TaxPayment = 'taxPayment',
+  VatPayment = 'vatPayment',
+  TaxRefund = 'taxRefund',
+  VatRefund = 'vatRefund'
+}
 
 export type TransactionFee = {
    __typename?: 'TransactionFee',

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -636,15 +636,15 @@ export type Transaction = {
 };
 
 export enum TransactionCategory {
-  Private = 'private',
-  Vat = 'vat',
-  Vat0 = 'vat0',
-  Vat7 = 'vat7',
-  Vat19 = 'vat19',
-  TaxPayment = 'taxPayment',
-  VatPayment = 'vatPayment',
-  TaxRefund = 'taxRefund',
-  VatRefund = 'vatRefund'
+  Private = 'PRIVATE',
+  Vat = 'VAT',
+  Vat_0 = 'VAT_0',
+  Vat_7 = 'VAT_7',
+  Vat_19 = 'VAT_19',
+  TaxPayment = 'TAX_PAYMENT',
+  VatPayment = 'VAT_PAYMENT',
+  TaxRefund = 'TAX_REFUND',
+  VatRefund = 'VAT_REFUND'
 }
 
 export type TransactionFee = {


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-backend/issues/5957

Just updating the part of the Schema relevant to the new transaction categories enum

**Note:** this is a *breaking* change. Webapp squad will need to be informed of this change when we release the SDK version containing these changes.

Corresponding backend PR: https://github.com/kontist/figure-backend/pull/6006