### PR TITLE
Fix async iterator return order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Async iterators now return results in the correct order (latest transactions / transfers first by default)
 
 ## [0.22.0] - 2019-11-26
 ### Added

--- a/lib/graphql/iterableModel.ts
+++ b/lib/graphql/iterableModel.ts
@@ -28,7 +28,7 @@ export abstract class IterableModel<
         if (lastResult.items.length > 0) {
           return {
             done: false,
-            value: lastResult.items.pop()
+            value: lastResult.items.shift()
           };
         }
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -51,3 +51,29 @@ export const createTransfer = (
     ...override
   };
 };
+
+export const generatePaginatedResponse = ({
+  key,
+  items,
+  pageInfo
+}: {
+  key: "transactions" | "transfers";
+  items: Array<Transaction | Transfer>;
+  pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean };
+}) => ({
+  viewer: {
+    mainAccount: {
+      [key]: {
+        edges: items.map(item => ({
+          node: item,
+          cursor: "1234"
+        })),
+        pageInfo: {
+          startCursor: "111111",
+          endCursor: "22222",
+          ...pageInfo
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
While writing some tests for the SDK on the backend, I noticed that the asyncIterator returned results in the reverse order for each 'batch' of items.

e.g. if I have 2 transactions first with booking date 2019-11-27 and second with booking date 2019-11-26, regular `fetch()` will return them in this order: `["2019-11-27", "2019-11-26"]` which is the order our GQL api also returns them by default (latest transactions always first), but `fetchAll()` will return them in the opposite order `["2019-11-26", "2019-11-27"]. I believe this is incorrect.

This was due to the fact that we used the `pop()` which will take the last item in the array to return each item in the async iterator logic.

We can simply change it to `shift()` to fix the issue.

Also our existing tests didn't demonstrate the issue because we only had pages with 1 item each, so I added a test with multiple items per page (and it would fail with previous `pop()` logic)