### PR TITLE
Fix transfer status filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Async iterators now return results in the correct order (latest transactions / transfers first by default)
+- Status filter for transfers is now working properly
 
 ## [0.22.0] - 2019-11-26
 ### Added

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -97,25 +97,41 @@ const CONFIRM_CANCEL_TRANSFER = `mutation confirmCancelTransfer(
   }
 }`;
 
-const FETCH_TRANSFERS = `query fetchTransfers ($type: TransferType!, $first: Int, $last: Int, $after: String, $before: String) {
-  viewer {
-    mainAccount {
-      transfers(type: $type, first: $first, last: $last, after: $after, before: $before) {
-        edges {
-          node {
-            ${TRANSFER_FIELDS}
+const FETCH_TRANSFERS = `
+  query fetchTransfers (
+    $type: TransferType!,
+    $where: TransfersConnectionFilter,
+    $first: Int,
+    $last: Int,
+    $after: String,
+    $before: String
+  ) {
+    viewer {
+      mainAccount {
+      transfers(
+        type: $type,
+        where: $where,
+        first: $first,
+        last: $last,
+        after: $after,
+        before: $before
+      ) {
+          edges {
+            node {
+              ${TRANSFER_FIELDS}
+            }
           }
-        }
-        pageInfo {
-          hasNextPage
-          hasPreviousPage
-          startCursor
-          endCursor
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
         }
       }
     }
   }
-}`;
+`;
 
 export class Transfer extends IterableModel<
   TransferModel,


### PR DESCRIPTION
While writing some tests for the SDK on the backend, I noticed that the status filter (e.g. `where: { status: "CONFIRMED" }`) for transfers was not working properly.

I forgot to add it to the actual queries 🤦‍♂ tested locally before and after the change, however I'm not sure if there is a proper way to add a "regression" test in the sdk? 

At least the backend tests I am currently writing will make sure that this works