### PR TITLE
Fix String -> string type

### DIFF
--- a/dist/lib/graphql/types.d.ts
+++ b/dist/lib/graphql/types.d.ts
@@ -10,7 +10,7 @@ export declare type TransferFetchOptions = {
     where?: TransfersConnectionFilter;
 } & FetchOptions;
 export declare type GetCardOptions = {
-    id: String;
+    id: string;
     type?: CardType;
 };
 export declare type CreateCardOptions = {

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -21,7 +21,7 @@ export type TransferFetchOptions = {
 } & FetchOptions;
 
 export type GetCardOptions = {
-  id: String;
+  id: string;
   type?: CardType;
 };
 


### PR DESCRIPTION
🤦‍♂It was still working with `String` but `string` is more proper (https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#general-types) and more consistent with the rest of the definitions