### PR TITLE
Add standing order update method

### DIFF
--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -353,6 +353,7 @@ export type Mutation = {
   deleteClient: Client,
   /** Create a transfer. The transfer's type will be determined based on the provided input */
   createTransfer: ConfirmationRequest,
+  updateTransfer: ConfirmationRequest,
   /** Confirm a transfer creation */
   confirmTransfer: Transfer,
   /** Create multiple transfers at once. Only regular SEPA Transfers are supported */
@@ -402,6 +403,11 @@ export type MutationDeleteClientArgs = {
 
 export type MutationCreateTransferArgs = {
   transfer: CreateTransferInput
+};
+
+
+export type MutationUpdateTransferArgs = {
+  transfer: UpdateTransferInput
 };
 
 
@@ -1048,6 +1054,22 @@ export type UpdateClientInput = {
   scopes?: Maybe<Array<ScopeType>>,
   /** The id of the OAuth2 client to update */
   id: Scalars['String'],
+};
+
+/** The available fields to update a Standing Order */
+export type UpdateTransferInput = {
+  /** The ID of the Standing Order to update */
+  id: Scalars['String'],
+  /** The amount of each Standing Order payment in cents */
+  amount: Scalars['Int'],
+  /** The date at which the last payment will be executed */
+  lastExecutionDate?: Maybe<Scalars['DateTime']>,
+  /** The purpose of the Standing Order - 140 max characters, if not specified with the update, it will be set to null */
+  purpose?: Maybe<Scalars['String']>,
+  /** The end to end ID of the Standing Order, if not specified with the update, it will be set to null */
+  e2eId?: Maybe<Scalars['String']>,
+  /** The reoccurrence type of the payments for Standing Orders */
+  reoccurrence?: Maybe<StandingOrderReoccurenceType>,
 };
 
 export type User = {

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -1,6 +1,7 @@
 import {
   Query,
   CreateTransferInput,
+  UpdateTransferInput,
   Transfer as TransferModel,
   BatchTransfer,
   TransferType,
@@ -147,6 +148,12 @@ const GET_TRANSFER_SUGGESTIONS = `
   }
 `;
 
+const UPDATE_TRANSFER = `mutation updateTransfer($transfer: UpdateTransferInput!) {
+  updateTransfer(transfer: $transfer) {
+    confirmationId
+  }
+}`;
+
 export class Transfer extends IterableModel<
   TransferModel,
   TransferFetchOptions
@@ -243,6 +250,17 @@ export class Transfer extends IterableModel<
       authorizationToken
     });
     return result.confirmCancelTransfer;
+  }
+
+  /**
+   * Update a standing order
+   *
+   * @param transfer  transfer data including at least id and amount
+   * @returns         confirmation id used to confirm the update
+   */
+  async update(transfer: UpdateTransferInput): Promise<string> {
+    const result = await this.client.rawQuery(UPDATE_TRANSFER, { transfer });
+    return result.updateTransfer.confirmationId;
   }
 
   /**

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -1,7 +1,11 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
 import { Transfer as TransferClass } from "../../lib/graphql/transfer";
-import { TransferType, Transfer } from "../../lib/graphql/schema";
+import {
+  TransferType,
+  Transfer,
+  StandingOrderReoccurenceType
+} from "../../lib/graphql/schema";
 import { createTransfer, generatePaginatedResponse } from "../helpers";
 
 describe("Transfer", () => {
@@ -216,6 +220,40 @@ describe("Transfer", () => {
         expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
         expect(result).to.eql([]);
       });
+    });
+  });
+
+  describe("update", () => {
+    const type = TransferType.StandingOrder;
+    const updatePayload = {
+      id: "some-id",
+      amount: 2345,
+      purpose: "some money",
+      e2eId: "some-e2e-id",
+      reoccurrence: StandingOrderReoccurenceType.Annually,
+      lastExecutionDate: "2022-02-02"
+    };
+    const confirmationId = "standing-order:123456789";
+
+    before(async () => {
+      graphqlClientStub.rawQuery.reset();
+      graphqlClientStub.rawQuery.resolves({
+        updateTransfer: {
+          confirmationId
+        }
+      });
+      result = await transferInstance.update(updatePayload);
+    });
+
+    it("should send updateTransfer GraphQL mutation", () => {
+      expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
+      const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
+      expect(query).to.include("updateTransfer");
+      expect(variables).to.eql({ transfer: updatePayload });
+    });
+
+    it("should return updateTransfer result", () => {
+      expect(result).to.eql(confirmationId);
     });
   });
 });


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-backend/issues/6216

Corresponding backend PR: https://github.com/kontist/figure-backend/pull/6248

In an effort to increase GraphQL / SDK coverage of our business logic, we want to add a way for users to update standing orders like they can do with the rest API