### PR TITLE
Use schema types instead manual ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- *Breaking*: changed card types to use schema types (CreateCardOptions, ActivateCardOptions, ChangeCardPINOptions, ConfirmChangeCardPINOptions, ChangeCardStatusOptions, UpdateCardSettingsOptions).
 
 ## [0.23.0] - 2020-01-17
 ### Added

--- a/lib/graphql/card.ts
+++ b/lib/graphql/card.ts
@@ -1,14 +1,8 @@
-import { Card as CardModel, Query, CardType, CardSettings } from "./schema";
+import { Card as CardModel, Query, CardSettings, MutationCreateCardArgs, MutationActivateCardArgs, MutationChangeCardPinArgs, MutationConfirmChangeCardPinArgs, MutationChangeCardStatusArgs, MutationUpdateCardSettingsArgs } from "./schema";
 import { Model } from "./model";
 import { ResultPage } from "./resultPage";
 import {
   GetCardOptions,
-  ActivateCardOptions,
-  ChangeCardPINOptions,
-  ConfirmChangeCardPINOptions,
-  ChangeCardStatusOptions,
-  CreateCardOptions,
-  UpdateCardSettingsOptions
 } from "./types";
 
 const CARD_FIELDS = `
@@ -221,10 +215,10 @@ export class Card extends Model<CardModel> {
   /**
    * Creates a card
    *
-   * @param args   query parameters including cardType
+   * @param args   query parameters including card type
    * @returns      the newly created card details
    */
-  async create(args: CreateCardOptions): Promise<CardModel> {
+  async create(args: MutationCreateCardArgs): Promise<CardModel> {
     const result = await this.client.rawQuery(CREATE_CARD, args);
     return result.createCard;
   }
@@ -235,7 +229,7 @@ export class Card extends Model<CardModel> {
    * @param args  query parameters including card id and verificationToken
    * @returns     activated card details
    */
-  async activate(args: ActivateCardOptions): Promise<CardModel> {
+  async activate(args: MutationActivateCardArgs): Promise<CardModel> {
     const result = await this.client.rawQuery(ACTIVATE_CARD, args);
     return result.activateCard;
   }
@@ -246,7 +240,7 @@ export class Card extends Model<CardModel> {
    * @param args   query parameters including card id and PIN number
    * @returns      confirmation id used to confirm the PIN change
    */
-  async changePIN(args: ChangeCardPINOptions): Promise<string> {
+  async changePIN(args: MutationChangeCardPinArgs): Promise<string> {
     const result = await this.client.rawQuery(CHANGE_CARD_PIN, args);
     return result.changeCardPIN.confirmationId;
   }
@@ -257,7 +251,7 @@ export class Card extends Model<CardModel> {
    * @param args   query parameters including card id and PIN number
    * @returns      PIN number change status
    */
-  async confirmChangePIN(args: ConfirmChangeCardPINOptions): Promise<string> {
+  async confirmChangePIN(args: MutationConfirmChangeCardPinArgs): Promise<string> {
     const result = await this.client.rawQuery(CONFIRM_CHANGE_CARD_PIN, args);
     return result.confirmChangeCardPIN.status;
   }
@@ -268,7 +262,7 @@ export class Card extends Model<CardModel> {
    * @param args   query parameters including card id and action
    * @returns      updated card details
    */
-  async changeStatus(args: ChangeCardStatusOptions): Promise<CardModel> {
+  async changeStatus(args: MutationChangeCardStatusArgs): Promise<CardModel> {
     const result = await this.client.rawQuery(CHANGE_CARD_STATUS, args);
     return result.changeCardStatus;
   }
@@ -279,7 +273,7 @@ export class Card extends Model<CardModel> {
    * @param args   query parameters including card id, contactlessEnabled, cardPresentLimits and cardNotPresentLimits
    * @returns      updated card settings
    */
-  async updateSettings(args: UpdateCardSettingsOptions): Promise<CardSettings> {
+  async updateSettings(args: MutationUpdateCardSettingsArgs["settings"] & Pick<MutationUpdateCardSettingsArgs, "id">): Promise<CardSettings> {
     const result = await this.client.rawQuery(UPDATE_CARD_SETTINGS, args);
     return result.updateCardSettings;
   }

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -3,9 +3,7 @@ import {
   Mutation,
   TransferType,
   TransfersConnectionFilter,
-  CardType,
-  CardAction,
-  CardLimitsInput
+  CardType
 } from "./schema";
 
 export type FetchOptions = {

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -25,38 +25,6 @@ export type GetCardOptions = {
   type?: CardType;
 };
 
-export type CreateCardOptions = {
-  type: string;
-};
-
-export type ActivateCardOptions = {
-  id: string;
-  verificationToken: string;
-};
-
-export type ChangeCardPINOptions = {
-  id: string;
-  pin: string;
-};
-
-export type ConfirmChangeCardPINOptions = {
-  id: string;
-  confirmationId: string;
-  authorizationToken: string;
-};
-
-export type ChangeCardStatusOptions = {
-  id: string;
-  action: CardAction;
-};
-
-export type UpdateCardSettingsOptions = {
-  id: string;
-  contactlessEnabled?: boolean;
-  cardNotPresentLimits?: CardLimitsInput;
-  cardPresentLimits?: CardLimitsInput;
-};
-
 export enum SubscriptionType {
   newTransaction = "newTransaction"
 }


### PR DESCRIPTION
We recently found a few manual types which could be replaced by existing autogenerated schema types. We should use them instead to avoid code duplication and manual work.