### PR TITLE
Add card reorder method

### DIFF
--- a/lib/graphql/card.ts
+++ b/lib/graphql/card.ts
@@ -1,4 +1,18 @@
-import { Card as CardModel, Query, CardSettings, MutationCreateCardArgs, MutationActivateCardArgs, MutationChangeCardPinArgs, MutationConfirmChangeCardPinArgs, MutationChangeCardStatusArgs, MutationUpdateCardSettingsArgs, MutationReplaceCardArgs } from "./schema";
+import {
+  Card as CardModel,
+  Query,
+  CardType,
+  CardSettings,
+  MutationCreateCardArgs,
+  MutationActivateCardArgs,
+  MutationChangeCardPinArgs,
+  MutationConfirmChangeCardPinArgs,
+  MutationChangeCardStatusArgs,
+  MutationUpdateCardSettingsArgs,
+  MutationReplaceCardArgs,
+  MutationReorderCardArgs
+} from "./schema";
+
 import { Model } from "./model";
 import { ResultPage } from "./resultPage";
 import {
@@ -180,6 +194,16 @@ const REPLACE_CARD = `mutation replaceCard(
   }
 }`;
 
+const REORDER_CARD = `mutation reorderCard(
+  $id: String!
+) {
+  reorderCard(
+    id: $id
+  ) {
+    ${CARD_FIELDS}
+  }
+}`;
+
 export class Card extends Model<CardModel> {
   /**
    * Fetches all cards belonging to the current user
@@ -292,10 +316,21 @@ export class Card extends Model<CardModel> {
    * Replace a card
    *
    * @param args   query parameters including card id
-   * @returns      the newly created card details
+   * @returns      updated card details
    */
   async replace(args: MutationReplaceCardArgs): Promise<CardModel> {
     const result = await this.client.rawQuery(REPLACE_CARD, args);
     return result.replaceCard;
+  }
+
+  /**
+   * Reorder a card
+   *
+   * @param args   query parameters including card id
+   * @returns      the newly created card details
+   */
+  async reorder(args: MutationReorderCardArgs): Promise<CardModel> {
+    const result = await this.client.rawQuery(REORDER_CARD, args);
+    return result.reorderCard;
   }
 }

--- a/tests/graphql/card.spec.ts
+++ b/tests/graphql/card.spec.ts
@@ -324,7 +324,7 @@ describe("Card", () => {
   });
 
   describe("#replace", () => {
-    it("should call rawQuery and return newly created card details", async () => {
+    it("should call rawQuery and return updated card details", async () => {
       // arrange;
       const newCardData = {
         ...cardData,
@@ -337,6 +337,29 @@ describe("Card", () => {
 
       // act
       const result = await card.replace({
+        id: cardData.id
+      });
+
+      // assert
+      sinon.assert.calledOnce(spyOnRawQuery);
+      expect(result).to.eq(newCardData);
+    });
+  });
+
+  describe("#reorder", () => {
+    it("should call rawQuery and return newly created card details", async () => {
+      // arrange;
+      const newCardData = {
+        ...cardData,
+        status: CardStatus.Processing
+      };
+      const card = new Card(client.graphQL);
+      const spyOnRawQuery = sandbox.stub(client.graphQL, "rawQuery").resolves({
+        reorderCard: newCardData
+      } as any);
+
+      // act
+      const result = await card.reorder({
         id: cardData.id
       });
 


### PR DESCRIPTION
Addresses: [4616](https://app.zenhub.com/workspaces/kontist-engineering-5be06ab44b5806bc2bf14eca/issues/kontist/figure-app/4616)

Corresponding backend PR: [6265](https://github.com/kontist/figure-backend/pull/6267)

`reorder` is different from `replace` method introduced in #61 in a way that `reorder` makes 2 calls to solaris (close current card + create new card) unlike `replace` which calls solaris replace endpoint once (`/cards/:card_id/replace`) and only updates existing card in db.

`reorder` method is called when customer's card is damaged.
`replace` method is called when customer's card is lost or stolen.