### PR TITLE
Add missing type hint

### DIFF
--- a/lib/auth/push.ts
+++ b/lib/auth/push.ts
@@ -45,7 +45,7 @@ export class PushNotificationMFA {
       HttpMethod.POST,
     );
 
-    return new Promise((resolve, reject) =>
+    return new Promise<Token>((resolve, reject) =>
       this.pollChallengeStatus(challenge, resolve, reject)(),
     );
   }


### PR DESCRIPTION
nit: Seems typescript does infer `Promise<unknown>` as type for `getConfirmedToken` which creates some type problems when we want to use that result.

push.d.ts:
```
    /**
     * Create an MFA challenge and request a confirmed access token when verified
     */
    getConfirmedToken: () => Promise<unknown>;
```