### PR TITLE
Extend create card mutation with cardHolderRepresentation

### DIFF
--- a/lib/graphql/card.ts
+++ b/lib/graphql/card.ts
@@ -100,10 +100,12 @@ const GET_CARD_LIMITS = `
 `;
 
 const CREATE_CARD = `mutation createCard(
-  $type: CardType!
+  $type: CardType!,
+  $cardHolderRepresentation: String
 ) {
   createCard(
-    type: $type
+    type: $type,
+    cardHolderRepresentation: $cardHolderRepresentation
   ) {
     ${CARD_FIELDS}
   }

--- a/tests/graphql/card.spec.ts
+++ b/tests/graphql/card.spec.ts
@@ -197,6 +197,7 @@ describe("Card", () => {
       // act
       const result = await card.create({
         type: CardType.VisaBusinessDebit,
+        cardHolderRepresentation: "No Name",
       });
 
       // assert


### PR DESCRIPTION
I forgot to add `cardHolderRepresentation` param in `createCard` mutation :(