### PR TITLE
Add filtering to transactions

### DIFF
--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -50,6 +50,7 @@ export type AccountTransactionArgs = {
 
 /** The bank account of the current user */
 export type AccountTransactionsArgs = {
+  filter?: Maybe<TransactionFilter>,
   first?: Maybe<Scalars['Int']>,
   last?: Maybe<Scalars['Int']>,
   after?: Maybe<Scalars['String']>,
@@ -68,6 +69,11 @@ export type AccountTransferArgs = {
 export type AccountCardArgs = {
   filter?: Maybe<CardFilter>
 };
+
+export enum BaseOperator {
+  Or = 'OR',
+  And = 'AND'
+}
 
 export type BatchTransfer = {
    __typename?: 'BatchTransfer',
@@ -839,6 +845,37 @@ export enum TransactionCategory {
   VatRefund = 'VAT_REFUND'
 }
 
+export type TransactionCondition = {
+  operator?: Maybe<BaseOperator>,
+  amount_lt?: Maybe<Scalars['Int']>,
+  amount_gt?: Maybe<Scalars['Int']>,
+  amount_gte?: Maybe<Scalars['Int']>,
+  amount_lte?: Maybe<Scalars['Int']>,
+  amount_eq?: Maybe<Scalars['Int']>,
+  amount_ne?: Maybe<Scalars['Int']>,
+  amount_in?: Maybe<Array<Scalars['Int']>>,
+  iban_eq?: Maybe<Scalars['String']>,
+  iban_ne?: Maybe<Scalars['String']>,
+  iban_like?: Maybe<Scalars['String']>,
+  iban_likeAny?: Maybe<Array<Scalars['String']>>,
+  iban_in?: Maybe<Array<Scalars['String']>>,
+  bookingDate_eq?: Maybe<Scalars['String']>,
+  bookingDate_ne?: Maybe<Scalars['String']>,
+  bookingDate_gt?: Maybe<Scalars['String']>,
+  bookingDate_lt?: Maybe<Scalars['String']>,
+  bookingDate_gte?: Maybe<Scalars['String']>,
+  bookingDate_lte?: Maybe<Scalars['String']>,
+  name_eq?: Maybe<Scalars['String']>,
+  name_ne?: Maybe<Scalars['String']>,
+  name_like?: Maybe<Scalars['String']>,
+  name_likeAny?: Maybe<Array<Scalars['String']>>,
+  name_in?: Maybe<Array<Scalars['String']>>,
+  purpose_eq?: Maybe<Scalars['String']>,
+  purpose_ne?: Maybe<Scalars['String']>,
+  purpose_like?: Maybe<Scalars['String']>,
+  purpose_likeAny?: Maybe<Array<Scalars['String']>>,
+};
+
 export type TransactionFee = {
    __typename?: 'TransactionFee',
   type: TransactionFeeType,
@@ -862,6 +899,38 @@ export enum TransactionFeeType {
   SecondReminderEmail = 'SECOND_REMINDER_EMAIL',
   CardReplacement = 'CARD_REPLACEMENT'
 }
+
+export type TransactionFilter = {
+  operator?: Maybe<BaseOperator>,
+  amount_lt?: Maybe<Scalars['Int']>,
+  amount_gt?: Maybe<Scalars['Int']>,
+  amount_gte?: Maybe<Scalars['Int']>,
+  amount_lte?: Maybe<Scalars['Int']>,
+  amount_eq?: Maybe<Scalars['Int']>,
+  amount_ne?: Maybe<Scalars['Int']>,
+  amount_in?: Maybe<Array<Scalars['Int']>>,
+  iban_eq?: Maybe<Scalars['String']>,
+  iban_ne?: Maybe<Scalars['String']>,
+  iban_like?: Maybe<Scalars['String']>,
+  iban_likeAny?: Maybe<Array<Scalars['String']>>,
+  iban_in?: Maybe<Array<Scalars['String']>>,
+  bookingDate_eq?: Maybe<Scalars['String']>,
+  bookingDate_ne?: Maybe<Scalars['String']>,
+  bookingDate_gt?: Maybe<Scalars['String']>,
+  bookingDate_lt?: Maybe<Scalars['String']>,
+  bookingDate_gte?: Maybe<Scalars['String']>,
+  bookingDate_lte?: Maybe<Scalars['String']>,
+  name_eq?: Maybe<Scalars['String']>,
+  name_ne?: Maybe<Scalars['String']>,
+  name_like?: Maybe<Scalars['String']>,
+  name_likeAny?: Maybe<Array<Scalars['String']>>,
+  name_in?: Maybe<Array<Scalars['String']>>,
+  purpose_eq?: Maybe<Scalars['String']>,
+  purpose_ne?: Maybe<Scalars['String']>,
+  purpose_like?: Maybe<Scalars['String']>,
+  purpose_likeAny?: Maybe<Array<Scalars['String']>>,
+  conditions?: Maybe<Array<TransactionCondition>>,
+};
 
 export enum TransactionProjectionType {
   CreditPresentment = 'CREDIT_PRESENTMENT',

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -31,25 +31,27 @@ const TRANSACTION_FIELDS = `
   documentType
 `;
 
-const FETCH_TRANSACTIONS = `query fetchTransactions ($first: Int, $last: Int, $after: String, $before: String) {
-  viewer {
-    mainAccount {
-      transactions(first: $first, last: $last, after: $after, before: $before) {
-        edges {
-          node {
-            ${TRANSACTION_FIELDS}
+const FETCH_TRANSACTIONS = `
+  query fetchTransactions ($first: Int, $last: Int, $after: String, $before: String, $filter: TransactionFilter) {
+    viewer {
+      mainAccount {
+        transactions(first: $first, last: $last, after: $after, before: $before, filter: $filter) {
+          edges {
+            node {
+              ${TRANSACTION_FIELDS}
+            }
           }
-        }
-        pageInfo {
-          hasNextPage
-          hasPreviousPage
-          startCursor
-          endCursor
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
         }
       }
     }
   }
-}`;
+`;
 
 export const NEW_TRANSACTION_SUBSCRIPTION = `subscription {
   newTransaction {

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -155,7 +155,7 @@ export class Transaction extends IterableModel<TransactionModel> {
     const amountTerms = searchTerms
       .filter((term) => amountRegex.test(term))
       .reduce((terms: number[], term: string): number[] => {
-        const amountInCents = parseFloat(term.replace(",", ".")) * 100;
+        const amountInCents = Math.round(parseFloat(term.replace(",", ".")) * 100);
         return [...terms, amountInCents, amountInCents * -1];
       } , []);
 

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -1,6 +1,7 @@
 import { IterableModel } from "./iterableModel";
 import { ResultPage } from "./resultPage";
 import {
+  AccountTransactionsArgs,
   MutationCategorizeTransactionArgs,
   Query,
   Transaction as TransactionModel,
@@ -77,7 +78,7 @@ export class Transaction extends IterableModel<TransactionModel> {
    * @param args  query parameters
    * @returns     result page
    */
-  public async fetch(args?: FetchOptions): Promise<ResultPage<TransactionModel>> {
+  public async fetch(args?: AccountTransactionsArgs): Promise<ResultPage<TransactionModel>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSACTIONS, args);
 
     const transactions = (

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -99,8 +99,8 @@ export class Transaction extends IterableModel<TransactionModel> {
   }
 
   /**
-   * Fetches first 50 matching transactions for a given user input
-   * It will consider case insentsitive like matches for amount,
+   * Fetches up to first 50 matching transactions for a given user input
+   * It will consider case insensitive like matches for amount,
    * iban, description, and name
    *
    * @param searchQuery  input query from user

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -1,6 +1,7 @@
 import { IterableModel } from "./iterableModel";
 import { ResultPage } from "./resultPage";
 import {
+  AccountTransfersArgs,
   BatchTransfer,
   ConfirmationRequestOrTransfer,
   CreateTransferInput,
@@ -11,7 +12,6 @@ import {
   TransferType,
   UpdateTransferInput,
 } from "./schema";
-import { TransferFetchOptions } from "./types";
 
 const TRANSFER_FIELDS = `
   id
@@ -156,7 +156,7 @@ const UPDATE_TRANSFER = `mutation updateTransfer($transfer: UpdateTransferInput!
 
 export class Transfer extends IterableModel<
   TransferModel,
-  TransferFetchOptions
+  AccountTransfersArgs
 > {
   /**
    * Creates single wire transfer / timed order / standing order
@@ -270,8 +270,8 @@ export class Transfer extends IterableModel<
    * @returns     result page
    */
   public async fetch(
-    args: TransferFetchOptions,
-  ): Promise<ResultPage<TransferModel, TransferFetchOptions>> {
+    args: AccountTransfersArgs,
+  ): Promise<ResultPage<TransferModel, AccountTransfersArgs>> {
     const result: Query = await this.client.rawQuery(FETCH_TRANSFERS, args);
 
     const transfers = (result?.viewer?.mainAccount?.transfers?.edges ?? []).map(

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,12 +1,15 @@
 import {
-  AccountTransactionsArgs,
-  AccountTransfersArgs,
   CardType,
   Mutation,
   Query,
 } from "./schema";
 
-export type FetchOptions = AccountTransactionsArgs | AccountTransfersArgs;
+export type FetchOptions = {
+  first?: number;
+  last?: number;
+  before?: string | null;
+  after?: string | null;
+};
 
 export type GetCardOptions = {
   id: string;

--- a/lib/graphql/types.ts
+++ b/lib/graphql/types.ts
@@ -1,22 +1,12 @@
 import {
+  AccountTransactionsArgs,
+  AccountTransfersArgs,
   CardType,
   Mutation,
   Query,
-  TransfersConnectionFilter,
-  TransferType,
 } from "./schema";
 
-export type FetchOptions = {
-  first?: number;
-  last?: number;
-  before?: string | null;
-  after?: string | null;
-};
-
-export type TransferFetchOptions = {
-  type: TransferType;
-  where?: TransfersConnectionFilter;
-} & FetchOptions;
+export type FetchOptions = AccountTransactionsArgs | AccountTransfersArgs;
 
 export type GetCardOptions = {
   id: string;

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -275,5 +275,26 @@ describe("Transaction", () => {
         });
       });
     });
+
+    describe("when user provides terms which are not valid amount", () => {
+      it("should call fetch without including amount filter", async () => {
+        // arrange
+        const userQuery = "1.123 -234, .10";
+
+        // act
+        await client.models.transaction.search(userQuery);
+
+        // assert
+        expect(fetchStub.callCount).to.eq(1);
+        expect(fetchStub.getCall(0).args[0]).to.deep.eq({
+          filter: {
+            iban_likeAny: ["1.123", "-234,", ".10"],
+            name_likeAny: ["1.123", "-234,", ".10"],
+            operator: BaseOperator.Or,
+            purpose_likeAny: ["1.123", "-234,", ".10"],
+          }
+        });
+      });
+    });
   });
 });

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -98,6 +98,16 @@ describe("Transaction", () => {
         }
       });
 
+      expect(stub.callCount).to.equal(1);
+      expect(stub.getCall(0).args[1]).to.deep.equal(
+        {
+          filter: {
+            operator: BaseOperator.And,
+            amount_gt: 1000,
+            name_like: "SaNtA"
+          }
+        }
+      );
       expect(results.items).to.deep.equal([
         firstTransaction,
         thirdTransaction,

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -257,7 +257,7 @@ describe("Transaction", () => {
     describe("when user provides a mix of numbers and text", () => {
       it("should call fetch with properly formatted filter", async () => {
         // arrange
-        const userQuery = "DE12345 -90,87 hello 5000";
+        const userQuery = "DE12345 -90,87 hello 33.91";
 
         // act
         await client.models.transaction.search(userQuery);
@@ -266,11 +266,11 @@ describe("Transaction", () => {
         expect(fetchStub.callCount).to.eq(1);
         expect(fetchStub.getCall(0).args[0]).to.deep.eq({
           filter: {
-            amount_in: [-9087, 9087, 500000, -500000],
-            iban_likeAny: ["DE12345", "-90,87", "hello", "5000"],
-            name_likeAny: ["DE12345", "-90,87", "hello", "5000"],
+            amount_in: [-9087, 9087, 3391, -3391],
+            iban_likeAny: ["DE12345", "-90,87", "hello", "33.91"],
+            name_likeAny: ["DE12345", "-90,87", "hello", "33.91"],
             operator: BaseOperator.Or,
-            purpose_likeAny: ["DE12345", "-90,87", "hello", "5000"],
+            purpose_likeAny: ["DE12345", "-90,87", "hello", "33.91"],
           }
         });
       });


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-backend/issues/6151

Corresponding backend PR: https://github.com/kontist/figure-backend/pull/6409

So I went with extending the fetch method to allow filter, and also added a "search" helper which does some formatting on a passed string to cover the most generic use case (the one we will need to implement in both webapp and native app).

I think it's nice to have this additional helper for unifying logic in both our apps, and also provide some easy to use method if users don't want to dig too deep into filters