### PR TITLE
updateTransfer for categorization data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- *Breaking*: update transfer can now return confirmation request (Standing Order) or Transfer (Sepa Transfer, Timed Order)
+- create transfer mutation allows now to provide category and booking date for Sepa Transfer, Standing Order and Timed Order
+- update transfer mutation allows now to provide category and booking date for pending Sepa Transfer, Standing Order, and Timed Order. `category` and `userSelectedBookingDate` are the only editable fields for Timed Order and pending Sepa Transfer
+- amount is not required anymore for an update of Standing Order
 
 ## [0.25.0] - 2020-02-19
 ### Added

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -261,6 +261,10 @@ export type CreateTransferInput = {
   e2eId?: Maybe<Scalars['String']>,
   /** The reoccurrence type of the payments for Standing Orders */
   reoccurrence?: Maybe<StandingOrderReoccurenceType>,
+  /** The user selected category for the SEPA Transfer */
+  category?: Maybe<TransactionCategory>,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: Maybe<Scalars['DateTime']>,
 };
 
 
@@ -323,7 +327,7 @@ export type Mutation = {
   deleteClient: Client,
   /** Create a transfer. The transfer's type will be determined based on the provided input */
   createTransfer: ConfirmationRequest,
-  updateTransfer: ConfirmationRequest,
+  updateTransfer: ConfirmationRequestOrTransfer,
   /** Confirm a transfer creation */
   confirmTransfer: Transfer,
   /** Create multiple transfers at once. Only regular SEPA Transfers are supported */
@@ -999,6 +1003,10 @@ export type Transfer = {
   reoccurrence?: Maybe<StandingOrderReoccurenceType>,
   /** The date at which the next payment will be executed for Standing Orders */
   nextOccurrence?: Maybe<Scalars['DateTime']>,
+  /** The user selected category for the SEPA Transfer */
+  category?: Maybe<Scalars['String']>,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: Maybe<Scalars['DateTime']>,
 };
 
 export type TransfersConnection = {
@@ -1060,14 +1068,14 @@ export type UpdateClientInput = {
   id: Scalars['String'],
 };
 
-/** The available fields to update a Standing Order */
+/** The available fields to update a transfer */
 export type UpdateTransferInput = {
-  /** The ID of the Standing Order to update */
+  /** The ID of the transfer to update */
   id: Scalars['String'],
   /** The type of transfer to update, currently only Standing Orders are supported */
-  type: TransferType,
-  /** The amount of each Standing Order payment in cents */
-  amount: Scalars['Int'],
+  type?: Maybe<TransferType>,
+  /** The amount of the Standing Order payment in cents */
+  amount?: Maybe<Scalars['Int']>,
   /** The date at which the last payment will be executed */
   lastExecutionDate?: Maybe<Scalars['DateTime']>,
   /** The purpose of the Standing Order - 140 max characters, if not specified with the update, it will be set to null */
@@ -1076,6 +1084,10 @@ export type UpdateTransferInput = {
   e2eId?: Maybe<Scalars['String']>,
   /** The reoccurrence type of the payments for Standing Orders */
   reoccurrence?: Maybe<StandingOrderReoccurenceType>,
+  /** The user selected category for the SEPA Transfer */
+  category?: Maybe<TransactionCategory>,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: Maybe<Scalars['DateTime']>,
 };
 
 export type User = {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1073,7 +1073,7 @@ export type UpdateTransferInput = {
   /** The ID of the transfer to update */
   id: Scalars['String'],
   /** The type of transfer to update, currently only Standing Orders are supported */
-  type?: Maybe<TransferType>,
+  type: TransferType,
   /** The amount of the Standing Order payment in cents */
   amount?: Maybe<Scalars['Int']>,
   /** The date at which the last payment will be executed */

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -261,7 +261,7 @@ export class Transfer extends IterableModel<
   /**
    * Update a standing order
    *
-   * @param transfer  transfer data including at least id and amount
+   * @param transfer  transfer data including at least id and type. For Timed Orders and Sepa Transfers, only category and userSelectedBooking date can be updated 
    * @returns         confirmation id used to confirm the update of Standing order or Transfer for Sepa Transfer / Timed Order
    */
   public async update(transfer: UpdateTransferInput): Promise<ConfirmationRequestOrTransfer> {

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -150,7 +150,13 @@ const GET_TRANSFER_SUGGESTIONS = `
 
 const UPDATE_TRANSFER = `mutation updateTransfer($transfer: UpdateTransferInput!) {
   updateTransfer(transfer: $transfer) {
-    confirmationId
+    ... on ConfirmationRequest {
+      confirmationId
+    }
+
+    ... on Transfer {
+      ${TRANSFER_FIELDS}
+    }
   }
 }`;
 
@@ -256,11 +262,11 @@ export class Transfer extends IterableModel<
    * Update a standing order
    *
    * @param transfer  transfer data including at least id and amount
-   * @returns         confirmation id used to confirm the update
+   * @returns         confirmation id used to confirm the update of Standing order or Transfer for Sepa Transfer / Timed Order
    */
-  public async update(transfer: UpdateTransferInput): Promise<string> {
+  public async update(transfer: UpdateTransferInput): Promise<ConfirmationRequestOrTransfer> {
     const result = await this.client.rawQuery(UPDATE_TRANSFER, { transfer });
-    return result.updateTransfer.confirmationId;
+    return result.updateTransfer;
   }
 
   /**

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -4,7 +4,8 @@ import { Transfer as TransferClass } from "../../lib/graphql/transfer";
 import {
   TransferType,
   Transfer,
-  StandingOrderReoccurenceType
+  StandingOrderReoccurenceType,
+  TransactionCategory
 } from "../../lib/graphql/schema";
 import { createTransfer, generatePaginatedResponse } from "../helpers";
 
@@ -223,7 +224,7 @@ describe("Transfer", () => {
     });
   });
 
-  describe("update", () => {
+  describe("update - Standing Order", () => {
     const updatePayload = {
       id: "some-id",
       amount: 2345,
@@ -253,7 +254,79 @@ describe("Transfer", () => {
     });
 
     it("should return updateTransfer result", () => {
-      expect(result).to.eql(confirmationId);
+      expect(result).to.eql({ confirmationId });
+    });
+  });
+
+  describe("update - SEPA Transfer", () => {
+    const category = TransactionCategory.TaxPayment;
+    const userSelectedBookingDate = new Date().toISOString();
+    const updatePayload = {
+      id: "some-id",
+      type: TransferType.SepaTransfer,
+      category,
+      userSelectedBookingDate
+    };
+
+    before(async () => {
+      graphqlClientStub.rawQuery.reset();
+      graphqlClientStub.rawQuery.resolves({
+        updateTransfer: {
+          category,
+          userSelectedBookingDate
+        }
+      });
+      result = await transferInstance.update(updatePayload);
+    });
+
+    it("should send updateTransfer GraphQL mutation", () => {
+      expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
+      const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
+      expect(query).to.include("updateTransfer");
+      expect(variables).to.eql({ transfer: updatePayload });
+    });
+
+    it("should return updateTransfer result", () => {
+      expect(result).to.eql({
+        category,
+        userSelectedBookingDate
+      });
+    });
+  });
+
+  describe("update - Timed Order", () => {
+    const category = TransactionCategory.TaxPayment;
+    const userSelectedBookingDate = new Date().toISOString();
+    const updatePayload = {
+      id: "some-id",
+      type: TransferType.TimedOrder,
+      category,
+      userSelectedBookingDate
+    };
+
+    before(async () => {
+      graphqlClientStub.rawQuery.reset();
+      graphqlClientStub.rawQuery.resolves({
+        updateTransfer: {
+          category,
+          userSelectedBookingDate
+        }
+      });
+      result = await transferInstance.update(updatePayload);
+    });
+
+    it("should send updateTransfer GraphQL mutation", () => {
+      expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
+      const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
+      expect(query).to.include("updateTransfer");
+      expect(variables).to.eql({ transfer: updatePayload });
+    });
+
+    it("should return updateTransfer result", () => {
+      expect(result).to.eql({
+        category,
+        userSelectedBookingDate
+      });
     });
   });
 });


### PR DESCRIPTION
With this PR client can update categorization metadata of standing order, timed order and sepa transfer.

This is blocked on https://github.com/kontist/figure-backend/compare/develop...epic/future-transaction-categorization