### PR TITLE
Limit amount searches to 20M€

### DIFF
--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -12,6 +12,7 @@ import {
 import { FetchOptions, Subscription, SubscriptionType } from "./types";
 
 const MAX_SEARCH_QUERY_LENGTH = 200;
+const MAX_SEARCH_AMOUNT_IN_CENTS = 2000000000;
 
 const TRANSACTION_FIELDS = `
   id
@@ -154,9 +155,13 @@ export class Transaction extends IterableModel<TransactionModel> {
     const amountTerms = searchTerms
       .filter((term) => amountRegex.test(term))
       .reduce((terms: number[], term: string): number[] => {
-        const amountInCents = Math.round(parseFloat(term.replace(",", ".")) * 100);
-        return [...terms, amountInCents, amountInCents * -1];
-      } , []);
+        const amountInCents = Math.round(
+          parseFloat(term.replace(",", ".")) * 100
+        );
+        return amountInCents > MAX_SEARCH_AMOUNT_IN_CENTS
+          ? terms
+          : [...terms, amountInCents, amountInCents * -1];
+      }, []);
 
     if (amountTerms.length > 0) {
       filter.amount_in = amountTerms;

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -325,5 +325,26 @@ describe("Transaction", () => {
         });
       });
     });
+
+    describe("when user provides number above 20 millions", () => {
+      it("should not include it as amount filter", async () => {
+        // arrange
+        const userQuery = "19999999 20000001 345678912";
+
+        // act
+        await client.models.transaction.search(userQuery);
+
+        // assert
+        expect(fetchStub.callCount).to.eq(1);
+        expect(fetchStub.getCall(0).args[0]).to.deep.eq({
+          filter: {
+            amount_in: [1999999900, -1999999900],
+            name_likeAny: ["19999999", "20000001", "345678912"],
+            operator: BaseOperator.Or,
+            purpose_likeAny: ["19999999", "20000001", "345678912"]
+          }
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Following a comment from @p-janik in app search PR: https://github.com/kontist/figure-app/pull/4867#issuecomment-592493816

> I noticed 500 when I typed magic number 123546182646481937464183940. We display skeleton then even if there is no fetch in background.

I looked a bit more and the `Int` GraphQL scalar type only supports 32 bit integers (see: https://github.com/graphql/graphql-spec/issues/73#issuecomment-129268000). If we specify a number above that, our GraphQL API will throw.

So I think it's a good idea to not include amount filter in search when user types a number above 20 millions (in euros).
This should be more than enough to cover all use cases.