### PR TITLE
Do not include empty strings as filters

### DIFF
--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -143,7 +143,10 @@ export class Transaction extends IterableModel<TransactionModel> {
   }
 
   private parseSearchQuery(searchQuery: string): TransactionFilter {
-    const searchTerms = searchQuery.slice(0, MAX_SEARCH_QUERY_LENGTH).split(" ");
+    const searchTerms = searchQuery
+      .slice(0, MAX_SEARCH_QUERY_LENGTH)
+      .split(" ")
+      .filter(term => term.length > 0);
 
     const filter: TransactionFilter = {
       name_likeAny: searchTerms,

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -346,5 +346,25 @@ describe("Transaction", () => {
         });
       });
     });
+
+    describe("when user provides several spaces back to back", () => {
+      it("should not include empty strings as filters", async () => {
+        // arrange
+        const userQuery = "  hello   world   ";
+
+        // act
+        await client.models.transaction.search(userQuery);
+
+        // assert
+        expect(fetchStub.callCount).to.eq(1);
+        expect(fetchStub.getCall(0).args[0]).to.deep.eq({
+          filter: {
+            name_likeAny: ["hello", "world"],
+            operator: BaseOperator.Or,
+            purpose_likeAny: ["hello", "world"]
+          }
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Another day, another issue in the search helper 😅

I previously didn't account for the fact that if users type several spaces back to back, we would include empty strings as filters (due to `split(" ")`). This is incorrect.

Open question: do you think we should also perform some validation backend side for this? i.e. should we allow users to `filter: { name_like: "" }` if they so choose? Currently this is allowed, and will return all transactions.