### PR TITLE
Match wild cent amounts when appropriate in search

### DIFF
--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -14,13 +14,19 @@ import { FetchOptions, Subscription, SubscriptionType } from "./types";
 const MAX_SEARCH_QUERY_LENGTH = 200;
 const MAX_SEARCH_AMOUNT_IN_CENTS = 2000000000;
 
-type AmountBetweenFilter = {
-  operator: BaseOperator;
-  amount_gte?: number;
-  amount_lte?: number;
-  amount_lt?: number;
-  amount_gt?: number;
+type PositiveAmountFilter = {
+  amount_gte: number;
+  amount_lt: number;
 }
+
+type NegativeAmountFilter = {
+  amount_lte: number;
+  amount_gt: number;
+}
+
+type AmountBetweenFilter = {
+  operator: BaseOperator.And;
+} & PositiveAmountFilter | NegativeAmountFilter;
 
 type AmountSearchFilter = {
   amount_in: number[];

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -14,6 +14,19 @@ import { FetchOptions, Subscription, SubscriptionType } from "./types";
 const MAX_SEARCH_QUERY_LENGTH = 200;
 const MAX_SEARCH_AMOUNT_IN_CENTS = 2000000000;
 
+type AmountBetweenFilter = {
+  operator: BaseOperator;
+  amount_gte?: number;
+  amount_lte?: number;
+  amount_lt?: number;
+  amount_gt?: number;
+}
+
+type AmountSearchFilter = {
+  amount_in: number[];
+  conditions: AmountBetweenFilter[];
+};
+
 const TRANSACTION_FIELDS = `
   id
   amount
@@ -142,6 +155,39 @@ export class Transaction extends IterableModel<TransactionModel> {
     return result.categorizeTransaction;
   }
 
+  private parseAmountSearchTerm(amountTerm: string): AmountSearchFilter {
+    const shouldMatchWildCents = !/[,.]/.test(amountTerm);
+    const amountInCents = Math.round(
+      parseFloat(amountTerm.replace(",", ".")) * 100
+    );
+
+    if (amountInCents > MAX_SEARCH_AMOUNT_IN_CENTS) {
+      return { amount_in: [], conditions: [] };
+    }
+
+    const invertedAmountInCents = amountInCents * -1;
+    const positiveAmountInCents = amountInCents > 0 ? amountInCents : invertedAmountInCents;
+    const negativeAmountInCents = amountInCents > 0 ? invertedAmountInCents : amountInCents;
+
+    return {
+      amount_in: [amountInCents, invertedAmountInCents],
+      conditions: shouldMatchWildCents
+        ? [
+            {
+              operator: BaseOperator.And,
+              amount_gte: positiveAmountInCents,
+              amount_lt: positiveAmountInCents + 100
+            },
+            {
+              operator: BaseOperator.And,
+              amount_gt: negativeAmountInCents - 100,
+              amount_lte: negativeAmountInCents
+            }
+          ]
+        : []
+    };
+  }
+
   private parseSearchQuery(searchQuery: string): TransactionFilter {
     const searchTerms = searchQuery
       .slice(0, MAX_SEARCH_QUERY_LENGTH)
@@ -151,27 +197,43 @@ export class Transaction extends IterableModel<TransactionModel> {
     const filter: TransactionFilter = {
       name_likeAny: searchTerms,
       operator: BaseOperator.Or,
-      purpose_likeAny: searchTerms,
+      purpose_likeAny: searchTerms
     };
 
     const amountRegex = /^-?\d+([,.]\d{1,2})?$/;
-    const amountTerms = searchTerms
-      .filter((term) => amountRegex.test(term))
-      .reduce((terms: number[], term: string): number[] => {
-        const amountInCents = Math.round(
-          parseFloat(term.replace(",", ".")) * 100
-        );
-        return amountInCents > MAX_SEARCH_AMOUNT_IN_CENTS
-          ? terms
-          : [...terms, amountInCents, amountInCents * -1];
-      }, []);
+    const amountFilter = searchTerms
+      .filter(term => amountRegex.test(term))
+      .reduce(
+        (
+          partialAmountFilter: AmountSearchFilter,
+          term: string
+        ): AmountSearchFilter => {
+          const parsedAmountSearchTerm = this.parseAmountSearchTerm(term);
 
-    if (amountTerms.length > 0) {
-      filter.amount_in = amountTerms;
+          return {
+            amount_in: [
+              ...partialAmountFilter.amount_in,
+              ...parsedAmountSearchTerm.amount_in
+            ],
+            conditions: [
+              ...partialAmountFilter.conditions,
+              ...parsedAmountSearchTerm.conditions
+            ]
+          };
+        },
+        { amount_in: [], conditions: [] }
+      );
+
+    if (amountFilter.amount_in.length > 0) {
+      filter.amount_in = amountFilter.amount_in;
+    }
+
+    if (amountFilter.conditions.length > 0) {
+      filter.conditions = amountFilter.conditions;
     }
 
     const ibanRegex = /^[A-Za-z]{2}\d{2,36}$/;
-    const ibanTerms = searchTerms.filter((term) => ibanRegex.test(term));
+    const ibanTerms = searchTerms.filter(term => ibanRegex.test(term));
 
     if (ibanTerms.length > 0) {
       filter.iban_likeAny = ibanTerms;

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -261,7 +261,7 @@ export class Transfer extends IterableModel<
   /**
    * Update a standing order
    *
-   * @param transfer  transfer data including at least id and type. For Timed Orders and Sepa Transfers, only category and userSelectedBooking date can be updated 
+   * @param transfer  transfer data including at least id and type. For Timed Orders and Sepa Transfers, only category and userSelectedBooking date can be updated
    * @returns         confirmation id used to confirm the update of Standing order or Transfer for Sepa Transfer / Timed Order
    */
   public async update(transfer: UpdateTransferInput): Promise<ConfirmationRequestOrTransfer> {

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -257,6 +257,28 @@ describe("Transaction", () => {
             name_likeAny: ["1234", "-567", "86.12", "90,1"],
             operator: BaseOperator.Or,
             purpose_likeAny: ["1234", "-567", "86.12", "90,1"],
+            conditions: [
+              {
+                amount_gte: 123400,
+                amount_lt: 123500,
+                operator: BaseOperator.And
+              },
+              {
+                amount_gt: -123500,
+                amount_lte: -123400,
+                operator: BaseOperator.And
+              },
+              {
+                amount_gte: 56700,
+                amount_lt: 56800,
+                operator: BaseOperator.And
+              },
+              {
+                amount_gt: -56800,
+                amount_lte: -56700,
+                operator: BaseOperator.And
+              }
+            ]
           }
         });
       });
@@ -321,6 +343,18 @@ describe("Transaction", () => {
             name_likeAny: ["DE4567", "E123", "1234", "FR12"],
             operator: BaseOperator.Or,
             purpose_likeAny: ["DE4567", "E123", "1234", "FR12"],
+            conditions: [
+              {
+                amount_gte: 123400,
+                amount_lt: 123500,
+                operator: BaseOperator.And
+              },
+              {
+                amount_gt: -123500,
+                amount_lte: -123400,
+                operator: BaseOperator.And
+              }
+            ]
           }
         });
       });
@@ -341,7 +375,19 @@ describe("Transaction", () => {
             amount_in: [1999999900, -1999999900],
             name_likeAny: ["19999999", "20000001", "345678912"],
             operator: BaseOperator.Or,
-            purpose_likeAny: ["19999999", "20000001", "345678912"]
+            purpose_likeAny: ["19999999", "20000001", "345678912"],
+            conditions: [
+              {
+                amount_gte: 1999999900,
+                amount_lt: 2000000000,
+                operator: BaseOperator.And
+              },
+              {
+                amount_gt: -2000000000,
+                amount_lte: -1999999900,
+                operator: BaseOperator.And
+              }
+            ]
           }
         });
       });


### PR DESCRIPTION
While testing search, Dani had the following idea regarding amount search:
> regarding the amounts I thought that maybe we could not include the 2 amounts after the comma.
> So if the amount is 1234,56 and I type 1234 it is shown.

That I translated by:
> mathematically, could we translate it as: if I type 1234 I should look for transactions which have amount >= 1234.00 in euros AND amount < 1235.00 in euros so:
> if I have the following amounts in my transactions: 1234.40 1234.51 1234.68 all of these would be returned?
> Negative values as well (-1234.89, -1234.32 ...)? because maybe you don't want to be bothered to type - for outgoing transactions

I think it makes perfect sense from a user's perspective that he would remember an amount in euros but not the details of the cents. Please advise if you think it's not proper?

Implementation is not complex, but the condition is starting to get a little bit complex itself.

Here is an example of results of such a filter locally:
<img width="1166" alt="Screenshot 2020-03-03 at 17 46 12" src="https://user-images.githubusercontent.com/3253522/75798932-9c1f2680-5d77-11ea-8094-531e5ef9511b.png">
