### PR TITLE
Add helper to set card holder representation

### DIFF
--- a/lib/graphql/card.ts
+++ b/lib/graphql/card.ts
@@ -205,6 +205,15 @@ const REORDER_CARD = `mutation reorderCard(
   }
 }`;
 
+
+export const SET_CARD_HOLDER_REPRESENTATION = `mutation setCardHolderRepresentation(
+  $cardHolderRepresentation: String!
+) {
+  setCardHolderRepresentation(
+    cardHolderRepresentation: $cardHolderRepresentation
+  )
+}`;
+
 export class Card extends Model<CardModel> {
   /**
    * Fetches all cards belonging to the current user
@@ -333,5 +342,20 @@ export class Card extends Model<CardModel> {
   public async reorder(args: MutationReorderCardArgs): Promise<CardModel> {
     const result = await this.client.rawQuery(REORDER_CARD, args);
     return result.reorderCard;
+  }
+
+  /**
+   * Updates a customer's card holder representation
+   *
+   * @param cardHolderRepresentation   the card holder representation to set
+   * @returns                          the updated card holder representation
+   */
+  public async setCardHolderRepresentation(
+    cardHolderRepresentation: string
+  ): Promise<string> {
+    const result = await this.client.rawQuery(SET_CARD_HOLDER_REPRESENTATION, {
+      cardHolderRepresentation
+    });
+    return result.setCardHolderRepresentation;
   }
 }

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -352,6 +352,8 @@ export type Mutation = {
   replaceCard: Card,
   /** Close and order new card. Call when customer's card is damaged */
   reorderCard: Card,
+  /** Set the card holder representation for the customer */
+  setCardHolderRepresentation: Scalars['String'],
   /** Categorize a transaction with an optional custom booking date for VAT or Tax categories */
   categorizeTransaction: Transaction,
 };

--- a/tests/graphql/card.spec.ts
+++ b/tests/graphql/card.spec.ts
@@ -369,4 +369,23 @@ describe("Card", () => {
       expect(result).to.eq(newCardData);
     });
   });
+
+  describe("#setCardHolderRepresentation", () => {
+    it("should call rawQuery and return the new card holder representation", async () => {
+      // arrange;
+      const cardHolderRepresentation = "JOHN/LENNON";
+      const card = new Card(client.graphQL);
+      const spyOnRawQuery = sandbox.stub(client.graphQL, "rawQuery").resolves({
+        setCardHolderRepresentation: cardHolderRepresentation
+      } as any);
+
+      // act
+      const result = await card.setCardHolderRepresentation(cardHolderRepresentation);
+
+      // assert
+      sinon.assert.calledOnce(spyOnRawQuery);
+      expect(spyOnRawQuery.getCall(0).args[1]).to.eql({ cardHolderRepresentation });
+      expect(result).to.eq(cardHolderRepresentation);
+    });
+  });
 });


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-backend/issues/6507

We need to add a way to set account's cardHolderRepresentation separately from solaris card creation.

We discussed that a distinct mutation / helper just for this purpose made the most sense.