### PR TITLE
Expose flow types

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -4,4 +4,8 @@ documents: null
 generates:
   lib/graphql/schema.ts:
     plugins:
-      - "typescript"
+      - typescript
+  lib/graphql/schema.flow.js:
+    plugins:
+      - flow
+

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1,0 +1,1390 @@
+/* @flow */
+
+
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {|
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
+  DateTime: any,
+|};
+
+/** The bank account of the current user */
+export type Account = {|
+   __typename?: 'Account',
+  iban: $ElementType<Scalars, 'String'>,
+  cardHolderRepresentation?: ?$ElementType<Scalars, 'String'>,
+  balance: $ElementType<Scalars, 'Int'>,
+  cardHolderRepresentations: Array<$ElementType<Scalars, 'String'>>,
+  transfers: TransfersConnection,
+  transaction?: ?Transaction,
+  transactions: TransactionsConnection,
+  transfer?: ?Transfer,
+  /** Individual tax-related settings per year */
+  taxYearSettings: Array<TaxYearSetting>,
+  /**
+   * A list of iban/name combinations based on existing user's transactions,
+   * provided to assist users when creating new transfers
+   */
+  transferSuggestions?: ?Array<TransferSuggestion>,
+  cards: Array<Card>,
+  card?: ?Card,
+  /** Overdraft Application - only available for Kontist Application */
+  overdraft?: ?Overdraft,
+|};
+
+
+/** The bank account of the current user */
+export type AccountTransfersArgs = {|
+  where?: ?TransfersConnectionFilter,
+  type: TransferType,
+  first?: ?$ElementType<Scalars, 'Int'>,
+  last?: ?$ElementType<Scalars, 'Int'>,
+  after?: ?$ElementType<Scalars, 'String'>,
+  before?: ?$ElementType<Scalars, 'String'>,
+|};
+
+
+/** The bank account of the current user */
+export type AccountTransactionArgs = {|
+  id: $ElementType<Scalars, 'ID'>,
+|};
+
+
+/** The bank account of the current user */
+export type AccountTransactionsArgs = {|
+  filter?: ?TransactionFilter,
+  first?: ?$ElementType<Scalars, 'Int'>,
+  last?: ?$ElementType<Scalars, 'Int'>,
+  after?: ?$ElementType<Scalars, 'String'>,
+  before?: ?$ElementType<Scalars, 'String'>,
+|};
+
+
+/** The bank account of the current user */
+export type AccountTransferArgs = {|
+  id: $ElementType<Scalars, 'ID'>,
+  type: TransferType,
+|};
+
+
+/** The bank account of the current user */
+export type AccountCardArgs = {|
+  filter?: ?CardFilter,
+|};
+
+export const BannerNameValues = Object.freeze({
+  Overdraft: 'OVERDRAFT'
+});
+
+
+export type BannerName = $Values<typeof BannerNameValues>;
+
+export const BaseOperatorValues = Object.freeze({
+  Or: 'OR', 
+  And: 'AND'
+});
+
+
+export type BaseOperator = $Values<typeof BaseOperatorValues>;
+
+export type BatchTransfer = {|
+   __typename?: 'BatchTransfer',
+  id: $ElementType<Scalars, 'String'>,
+  status: BatchTransferStatus,
+  transfers: Array<SepaTransfer>,
+|};
+
+export const BatchTransferStatusValues = Object.freeze({
+  AuthorizationRequired: 'AUTHORIZATION_REQUIRED', 
+  ConfirmationRequired: 'CONFIRMATION_REQUIRED', 
+  Accepted: 'ACCEPTED', 
+  Failed: 'FAILED', 
+  Successful: 'SUCCESSFUL'
+});
+
+
+export type BatchTransferStatus = $Values<typeof BatchTransferStatusValues>;
+
+export type Card = {|
+   __typename?: 'Card',
+  id: $ElementType<Scalars, 'String'>,
+  status: CardStatus,
+  type: CardType,
+  pinSet: $ElementType<Scalars, 'Boolean'>,
+  holder?: ?$ElementType<Scalars, 'String'>,
+  formattedExpirationDate?: ?$ElementType<Scalars, 'String'>,
+  maskedPan?: ?$ElementType<Scalars, 'String'>,
+  settings: CardSettings,
+|};
+
+export const CardActionValues = Object.freeze({
+  Close: 'CLOSE', 
+  Block: 'BLOCK', 
+  Unblock: 'UNBLOCK'
+});
+
+
+export type CardAction = $Values<typeof CardActionValues>;
+
+export type CardFilter = {|
+  id?: ?$ElementType<Scalars, 'String'>,
+  type?: ?CardType,
+|};
+
+export type CardLimit = {|
+   __typename?: 'CardLimit',
+  maxAmountCents: $ElementType<Scalars, 'Float'>,
+  maxTransactions: $ElementType<Scalars, 'Float'>,
+|};
+
+export type CardLimitInput = {|
+  maxAmountCents: $ElementType<Scalars, 'Float'>,
+  maxTransactions: $ElementType<Scalars, 'Float'>,
+|};
+
+export type CardLimits = {|
+   __typename?: 'CardLimits',
+  daily: CardLimit,
+  monthly: CardLimit,
+|};
+
+export type CardLimitsInput = {|
+  daily: CardLimitInput,
+  monthly: CardLimitInput,
+|};
+
+export type CardSettings = {|
+   __typename?: 'CardSettings',
+  contactlessEnabled: $ElementType<Scalars, 'Boolean'>,
+  cardPresentLimits?: ?CardLimits,
+  cardNotPresentLimits?: ?CardLimits,
+|};
+
+export type CardSettingsInput = {|
+  cardPresentLimits?: ?CardLimitsInput,
+  cardNotPresentLimits?: ?CardLimitsInput,
+  contactlessEnabled?: ?$ElementType<Scalars, 'Boolean'>,
+|};
+
+export const CardStatusValues = Object.freeze({
+  Processing: 'PROCESSING', 
+  Inactive: 'INACTIVE', 
+  Active: 'ACTIVE', 
+  Blocked: 'BLOCKED', 
+  BlockedBySolaris: 'BLOCKED_BY_SOLARIS', 
+  ActivationBlockedBySolaris: 'ACTIVATION_BLOCKED_BY_SOLARIS', 
+  Closed: 'CLOSED', 
+  ClosedBySolaris: 'CLOSED_BY_SOLARIS'
+});
+
+
+export type CardStatus = $Values<typeof CardStatusValues>;
+
+export const CardTypeValues = Object.freeze({
+  VirtualVisaBusinessDebit: 'VIRTUAL_VISA_BUSINESS_DEBIT', 
+  VisaBusinessDebit: 'VISA_BUSINESS_DEBIT', 
+  MastercardBusinessDebit: 'MASTERCARD_BUSINESS_DEBIT', 
+  VirtualMastercardBusinessDebit: 'VIRTUAL_MASTERCARD_BUSINESS_DEBIT', 
+  VirtualVisaFreelanceDebit: 'VIRTUAL_VISA_FREELANCE_DEBIT'
+});
+
+
+export type CardType = $Values<typeof CardTypeValues>;
+
+export type Client = {|
+   __typename?: 'Client',
+  id: $ElementType<Scalars, 'ID'>,
+  /** The URL to redirect to after authentication */
+  redirectUri?: ?$ElementType<Scalars, 'String'>,
+  /** The name of the OAuth2 client displayed when users log in */
+  name: $ElementType<Scalars, 'String'>,
+  /** The grant types (i.e. ways to obtain access tokens) allowed for the client */
+  grantTypes?: ?Array<GrantType>,
+  /** The scopes the client has access to, limiting access to the corresponding parts of the API */
+  scopes?: ?Array<ScopeType>,
+|};
+
+export const CompanyTypeValues = Object.freeze({
+  Selbstaendig: 'SELBSTAENDIG', 
+  Einzelunternehmer: 'EINZELUNTERNEHMER', 
+  Freiberufler: 'FREIBERUFLER', 
+  Gewerbetreibender: 'GEWERBETREIBENDER', 
+  Limited: 'LIMITED', 
+  EK: 'E_K', 
+  Partgg: 'PARTGG', 
+  Gbr: 'GBR', 
+  Ohg: 'OHG', 
+  Kg: 'KG', 
+  Kgaa: 'KGAA', 
+  Gmbh: 'GMBH', 
+  GmbhUndCoKg: 'GMBH_UND_CO_KG', 
+  Ug: 'UG'
+});
+
+
+export type CompanyType = $Values<typeof CompanyTypeValues>;
+
+export type ConfirmationRequest = {|
+   __typename?: 'ConfirmationRequest',
+  confirmationId: $ElementType<Scalars, 'String'>,
+|};
+
+export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
+
+export type ConfirmationStatus = {|
+   __typename?: 'ConfirmationStatus',
+  status: $ElementType<Scalars, 'String'>,
+|};
+
+export type ConfirmFraudResponse = {|
+   __typename?: 'ConfirmFraudResponse',
+  id: $ElementType<Scalars, 'String'>,
+  resolution: $ElementType<Scalars, 'String'>,
+|};
+
+/** The available fields to create an OAuth2 client */
+export type CreateClientInput = {|
+  /** The name of the OAuth2 client displayed when users log in */
+  name: $ElementType<Scalars, 'String'>,
+  /** The OAuth2 client secret */
+  secret?: ?$ElementType<Scalars, 'String'>,
+  /** The URL to redirect to after authentication */
+  redirectUri?: ?$ElementType<Scalars, 'String'>,
+  /** The grant types (i.e. ways to obtain access tokens) allowed for the client */
+  grantTypes: Array<GrantType>,
+  /** The scopes the client has access to, limiting access to the corresponding parts of the API */
+  scopes: Array<ScopeType>,
+|};
+
+/** The available fields to create a SEPA Transfer */
+export type CreateSepaTransferInput = {|
+  /** The name of the SEPA Transfer recipient */
+  recipient: $ElementType<Scalars, 'String'>,
+  /** The IBAN of the SEPA Transfer recipient */
+  iban: $ElementType<Scalars, 'String'>,
+  /** The amount of the SEPA Transfer in cents */
+  amount: $ElementType<Scalars, 'Int'>,
+  /** The purpose of the SEPA Transfer - 140 max characters */
+  purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The end to end ID of the SEPA Transfer */
+  e2eId?: ?$ElementType<Scalars, 'String'>,
+|};
+
+export type CreateTransactionSplitsInput = {|
+  amount: $ElementType<Scalars, 'Int'>,
+  category: TransactionCategory,
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+/** The available fields to create a transfer */
+export type CreateTransferInput = {|
+  /** The name of the transfer recipient */
+  recipient: $ElementType<Scalars, 'String'>,
+  /** The IBAN of the transfer recipient */
+  iban: $ElementType<Scalars, 'String'>,
+  /** The amount of the transfer in cents */
+  amount: $ElementType<Scalars, 'Int'>,
+  /** The date at which the payment will be executed for Timed Orders or Standing Orders */
+  executeAt?: ?$ElementType<Scalars, 'DateTime'>,
+  /** The date at which the last payment will be executed for Standing Orders */
+  lastExecutionDate?: ?$ElementType<Scalars, 'DateTime'>,
+  /** The purpose of the transfer - 140 max characters */
+  purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The end to end ID of the transfer */
+  e2eId?: ?$ElementType<Scalars, 'String'>,
+  /** The reoccurrence type of the payments for Standing Orders */
+  reoccurrence?: ?StandingOrderReoccurenceType,
+  /** The user selected category for the SEPA Transfer */
+  category?: ?TransactionCategory,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+
+export type DirectDebitFee = {|
+   __typename?: 'DirectDebitFee',
+  id: $ElementType<Scalars, 'Int'>,
+  type: TransactionFeeType,
+  name: $ElementType<Scalars, 'String'>,
+  amount: $ElementType<Scalars, 'Int'>,
+  usedAt?: ?$ElementType<Scalars, 'DateTime'>,
+  invoiceStatus: InvoiceStatus,
+|};
+
+export const DocumentTypeValues = Object.freeze({
+  Voucher: 'VOUCHER', 
+  Invoice: 'INVOICE'
+});
+
+
+export type DocumentType = $Values<typeof DocumentTypeValues>;
+
+export const GenderValues = Object.freeze({
+  Male: 'MALE', 
+  Female: 'FEMALE'
+});
+
+
+export type Gender = $Values<typeof GenderValues>;
+
+export const GrantTypeValues = Object.freeze({
+  Password: 'PASSWORD', 
+  AuthorizationCode: 'AUTHORIZATION_CODE', 
+  RefreshToken: 'REFRESH_TOKEN', 
+  ClientCredentials: 'CLIENT_CREDENTIALS'
+});
+
+
+export type GrantType = $Values<typeof GrantTypeValues>;
+
+export const IdentificationStatusValues = Object.freeze({
+  Pending: 'PENDING', 
+  PendingSuccessful: 'PENDING_SUCCESSFUL', 
+  PendingFailed: 'PENDING_FAILED', 
+  Successful: 'SUCCESSFUL', 
+  Failed: 'FAILED', 
+  Expired: 'EXPIRED', 
+  Created: 'CREATED', 
+  Aborted: 'ABORTED', 
+  Canceled: 'CANCELED'
+});
+
+
+export type IdentificationStatus = $Values<typeof IdentificationStatusValues>;
+
+export const InvoiceStatusValues = Object.freeze({
+  Open: 'OPEN', 
+  Closed: 'CLOSED', 
+  Rejected: 'REJECTED', 
+  Pending: 'PENDING'
+});
+
+
+export type InvoiceStatus = $Values<typeof InvoiceStatusValues>;
+
+export type Mutation = {|
+   __typename?: 'Mutation',
+  /** Cancel an existing Timed Order or Standing Order */
+  cancelTransfer: ConfirmationRequestOrTransfer,
+  /** Confirm a Standing Order cancelation */
+  confirmCancelTransfer: Transfer,
+  /** Create an OAuth2 client */
+  createClient: Client,
+  /** Update an OAuth2 client */
+  updateClient: Client,
+  /** Delete an OAuth2 client */
+  deleteClient: Client,
+  /** Update individual tax-related settings per year */
+  updateTaxYearSettings: Array<TaxYearSetting>,
+  /** Create a transfer. The transfer's type will be determined based on the provided input */
+  createTransfer: ConfirmationRequest,
+  updateTransfer: ConfirmationRequestOrTransfer,
+  /** Confirm a transfer creation */
+  confirmTransfer: Transfer,
+  /** Create multiple transfers at once. Only regular SEPA Transfers are supported */
+  createTransfers: ConfirmationRequest,
+  /** Confirm the transfers creation */
+  confirmTransfers: BatchTransfer,
+  /** Update user's subscription plan */
+  updateSubscriptionPlan: UpdateSubscriptionPlanResult,
+  whitelistCard: WhitelistCardResponse,
+  confirmFraud: ConfirmFraudResponse,
+  /** Create a new card */
+  createCard: Card,
+  /** Activate a card */
+  activateCard: Card,
+  /** Update settings (e.g. limits) */
+  updateCardSettings: CardSettings,
+  /** Block or unblock or close a card */
+  changeCardStatus: Card,
+  /** Set a new PIN, needs to be confirmed */
+  changeCardPIN: ConfirmationRequest,
+  /** Confirm a PIN change request */
+  confirmChangeCardPIN: ConfirmationStatus,
+  /** Call when customer's card is lost or stolen */
+  replaceCard: Card,
+  /** Close and order new card. Call when customer's card is damaged */
+  reorderCard: Card,
+  /** Set the card holder representation for the customer */
+  setCardHolderRepresentation: $ElementType<Scalars, 'String'>,
+  /** Categorize a transaction with an optional custom booking date for VAT or Tax categories */
+  categorizeTransaction: Transaction,
+  /** Create Overdraft Application  - only available for Kontist Application */
+  requestOverdraft?: ?Overdraft,
+  /** Create transaction splits */
+  createTransactionSplits: Transaction,
+  /** Update transaction splits */
+  updateTransactionSplits: Transaction,
+  /** Delete transaction splits */
+  deleteTransactionSplits: Transaction,
+  dismissBanner: MutationResult,
+|};
+
+
+export type MutationCancelTransferArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+  type: TransferType,
+|};
+
+
+export type MutationConfirmCancelTransferArgs = {|
+  authorizationToken: $ElementType<Scalars, 'String'>,
+  confirmationId: $ElementType<Scalars, 'String'>,
+  type: TransferType,
+|};
+
+
+export type MutationCreateClientArgs = {|
+  client: CreateClientInput,
+|};
+
+
+export type MutationUpdateClientArgs = {|
+  client: UpdateClientInput,
+|};
+
+
+export type MutationDeleteClientArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationUpdateTaxYearSettingsArgs = {|
+  taxYearSettings: Array<TaxYearSettingInput>,
+|};
+
+
+export type MutationCreateTransferArgs = {|
+  transfer: CreateTransferInput,
+|};
+
+
+export type MutationUpdateTransferArgs = {|
+  transfer: UpdateTransferInput,
+|};
+
+
+export type MutationConfirmTransferArgs = {|
+  authorizationToken: $ElementType<Scalars, 'String'>,
+  confirmationId: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationCreateTransfersArgs = {|
+  transfers: Array<CreateSepaTransferInput>,
+|};
+
+
+export type MutationConfirmTransfersArgs = {|
+  authorizationToken: $ElementType<Scalars, 'String'>,
+  confirmationId: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationUpdateSubscriptionPlanArgs = {|
+  newPlan: PurchaseType,
+|};
+
+
+export type MutationWhitelistCardArgs = {|
+  fraudCaseId: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationConfirmFraudArgs = {|
+  fraudCaseId: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationCreateCardArgs = {|
+  type: CardType,
+  cardHolderRepresentation?: ?$ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationActivateCardArgs = {|
+  verificationToken: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationUpdateCardSettingsArgs = {|
+  settings: CardSettingsInput,
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationChangeCardStatusArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+  action: CardAction,
+|};
+
+
+export type MutationChangeCardPinArgs = {|
+  pin: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationConfirmChangeCardPinArgs = {|
+  authorizationToken: $ElementType<Scalars, 'String'>,
+  confirmationId: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationReplaceCardArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationReorderCardArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationSetCardHolderRepresentationArgs = {|
+  cardHolderRepresentation: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationCategorizeTransactionArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+  category?: ?TransactionCategory,
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+
+export type MutationCreateTransactionSplitsArgs = {|
+  splits: Array<CreateTransactionSplitsInput>,
+  transactionId: $ElementType<Scalars, 'ID'>,
+|};
+
+
+export type MutationUpdateTransactionSplitsArgs = {|
+  splits: Array<UpdateTransactionSplitsInput>,
+  transactionId: $ElementType<Scalars, 'ID'>,
+|};
+
+
+export type MutationDeleteTransactionSplitsArgs = {|
+  transactionId: $ElementType<Scalars, 'ID'>,
+|};
+
+
+export type MutationDismissBannerArgs = {|
+  name: BannerName,
+|};
+
+export type MutationResult = {|
+   __typename?: 'MutationResult',
+  success: $ElementType<Scalars, 'Boolean'>,
+|};
+
+export const NationalityValues = Object.freeze({
+  De: 'DE', 
+  Ad: 'AD', 
+  Ae: 'AE', 
+  Af: 'AF', 
+  Ag: 'AG', 
+  Ai: 'AI', 
+  Al: 'AL', 
+  Am: 'AM', 
+  Ao: 'AO', 
+  Aq: 'AQ', 
+  Ar: 'AR', 
+  As: 'AS', 
+  At: 'AT', 
+  Au: 'AU', 
+  Aw: 'AW', 
+  Ax: 'AX', 
+  Az: 'AZ', 
+  Ba: 'BA', 
+  Bb: 'BB', 
+  Bd: 'BD', 
+  Be: 'BE', 
+  Bf: 'BF', 
+  Bg: 'BG', 
+  Bh: 'BH', 
+  Bi: 'BI', 
+  Bj: 'BJ', 
+  Bl: 'BL', 
+  Bm: 'BM', 
+  Bn: 'BN', 
+  Bo: 'BO', 
+  Br: 'BR', 
+  Bs: 'BS', 
+  Bt: 'BT', 
+  Bv: 'BV', 
+  Bw: 'BW', 
+  By: 'BY', 
+  Bz: 'BZ', 
+  Ca: 'CA', 
+  Cc: 'CC', 
+  Cd: 'CD', 
+  Cf: 'CF', 
+  Cg: 'CG', 
+  Ch: 'CH', 
+  Ci: 'CI', 
+  Ck: 'CK', 
+  Cl: 'CL', 
+  Cm: 'CM', 
+  Cn: 'CN', 
+  Co: 'CO', 
+  Cr: 'CR', 
+  Cu: 'CU', 
+  Cv: 'CV', 
+  Cw: 'CW', 
+  Cx: 'CX', 
+  Cy: 'CY', 
+  Cz: 'CZ', 
+  Dj: 'DJ', 
+  Dk: 'DK', 
+  Dm: 'DM', 
+  Do: 'DO', 
+  Dz: 'DZ', 
+  Ec: 'EC', 
+  Ee: 'EE', 
+  Eg: 'EG', 
+  Eh: 'EH', 
+  Er: 'ER', 
+  Es: 'ES', 
+  Et: 'ET', 
+  Fi: 'FI', 
+  Fj: 'FJ', 
+  Fk: 'FK', 
+  Fm: 'FM', 
+  Fo: 'FO', 
+  Fr: 'FR', 
+  Ga: 'GA', 
+  Gb: 'GB', 
+  Gd: 'GD', 
+  Ge: 'GE', 
+  Gf: 'GF', 
+  Gg: 'GG', 
+  Gh: 'GH', 
+  Gi: 'GI', 
+  Gl: 'GL', 
+  Gm: 'GM', 
+  Gn: 'GN', 
+  Gp: 'GP', 
+  Gq: 'GQ', 
+  Gr: 'GR', 
+  Gs: 'GS', 
+  Gt: 'GT', 
+  Gu: 'GU', 
+  Gw: 'GW', 
+  Gy: 'GY', 
+  Hk: 'HK', 
+  Hm: 'HM', 
+  Hn: 'HN', 
+  Hr: 'HR', 
+  Ht: 'HT', 
+  Hu: 'HU', 
+  Id: 'ID', 
+  Ie: 'IE', 
+  Il: 'IL', 
+  Im: 'IM', 
+  In: 'IN', 
+  Io: 'IO', 
+  Iq: 'IQ', 
+  Ir: 'IR', 
+  Is: 'IS', 
+  It: 'IT', 
+  Je: 'JE', 
+  Jm: 'JM', 
+  Jo: 'JO', 
+  Jp: 'JP', 
+  Ke: 'KE', 
+  Kg: 'KG', 
+  Kh: 'KH', 
+  Ki: 'KI', 
+  Km: 'KM', 
+  Kn: 'KN', 
+  Kp: 'KP', 
+  Kr: 'KR', 
+  Kw: 'KW', 
+  Ky: 'KY', 
+  Kz: 'KZ', 
+  La: 'LA', 
+  Lb: 'LB', 
+  Lc: 'LC', 
+  Li: 'LI', 
+  Lk: 'LK', 
+  Lr: 'LR', 
+  Ls: 'LS', 
+  Lt: 'LT', 
+  Lu: 'LU', 
+  Lv: 'LV', 
+  Ly: 'LY', 
+  Ma: 'MA', 
+  Mc: 'MC', 
+  Md: 'MD', 
+  Me: 'ME', 
+  Mf: 'MF', 
+  Mg: 'MG', 
+  Mh: 'MH', 
+  Mk: 'MK', 
+  Ml: 'ML', 
+  Mm: 'MM', 
+  Mn: 'MN', 
+  Mo: 'MO', 
+  Mp: 'MP', 
+  Mq: 'MQ', 
+  Mr: 'MR', 
+  Ms: 'MS', 
+  Mt: 'MT', 
+  Mu: 'MU', 
+  Mv: 'MV', 
+  Mw: 'MW', 
+  Mx: 'MX', 
+  My: 'MY', 
+  Mz: 'MZ', 
+  Na: 'NA', 
+  Nc: 'NC', 
+  Ne: 'NE', 
+  Nf: 'NF', 
+  Ng: 'NG', 
+  Ni: 'NI', 
+  Nl: 'NL', 
+  No: 'NO', 
+  Np: 'NP', 
+  Nr: 'NR', 
+  Nu: 'NU', 
+  Nz: 'NZ', 
+  Om: 'OM', 
+  Pa: 'PA', 
+  Pe: 'PE', 
+  Pf: 'PF', 
+  Pg: 'PG', 
+  Ph: 'PH', 
+  Pk: 'PK', 
+  Pl: 'PL', 
+  Pm: 'PM', 
+  Pn: 'PN', 
+  Pr: 'PR', 
+  Ps: 'PS', 
+  Pt: 'PT', 
+  Pw: 'PW', 
+  Py: 'PY', 
+  Qa: 'QA', 
+  Re: 'RE', 
+  Ro: 'RO', 
+  Rs: 'RS', 
+  Ru: 'RU', 
+  Rw: 'RW', 
+  Sa: 'SA', 
+  Sb: 'SB', 
+  Sc: 'SC', 
+  Sd: 'SD', 
+  Se: 'SE', 
+  Sg: 'SG', 
+  Si: 'SI', 
+  Sj: 'SJ', 
+  Sk: 'SK', 
+  Sl: 'SL', 
+  Sm: 'SM', 
+  Sn: 'SN', 
+  So: 'SO', 
+  Sr: 'SR', 
+  Ss: 'SS', 
+  St: 'ST', 
+  Sv: 'SV', 
+  Sx: 'SX', 
+  Sy: 'SY', 
+  Sz: 'SZ', 
+  Tc: 'TC', 
+  Td: 'TD', 
+  Tf: 'TF', 
+  Tg: 'TG', 
+  Th: 'TH', 
+  Tj: 'TJ', 
+  Tk: 'TK', 
+  Tl: 'TL', 
+  Tm: 'TM', 
+  Tn: 'TN', 
+  To: 'TO', 
+  Tr: 'TR', 
+  Tt: 'TT', 
+  Tv: 'TV', 
+  Tw: 'TW', 
+  Tz: 'TZ', 
+  Ua: 'UA', 
+  Ug: 'UG', 
+  Um: 'UM', 
+  Us: 'US', 
+  Uy: 'UY', 
+  Uz: 'UZ', 
+  Va: 'VA', 
+  Vc: 'VC', 
+  Ve: 'VE', 
+  Vg: 'VG', 
+  Vi: 'VI', 
+  Vn: 'VN', 
+  Vu: 'VU', 
+  Wf: 'WF', 
+  Ws: 'WS', 
+  Xk: 'XK', 
+  Ye: 'YE', 
+  Yt: 'YT', 
+  Za: 'ZA', 
+  Zm: 'ZM', 
+  Zw: 'ZW'
+});
+
+
+export type Nationality = $Values<typeof NationalityValues>;
+
+export type Overdraft = {|
+   __typename?: 'Overdraft',
+  id: $ElementType<Scalars, 'String'>,
+  /** Overdraft status */
+  status: OverdraftApplicationStatus,
+  /** Available overdraft limit */
+  limit?: ?$ElementType<Scalars, 'Int'>,
+|};
+
+export const OverdraftApplicationStatusValues = Object.freeze({
+  Created: 'CREATED', 
+  InitialScoringPending: 'INITIAL_SCORING_PENDING', 
+  AccountSnapshotPending: 'ACCOUNT_SNAPSHOT_PENDING', 
+  AccountSnapshotVerificationPending: 'ACCOUNT_SNAPSHOT_VERIFICATION_PENDING', 
+  Offered: 'OFFERED', 
+  Rejected: 'REJECTED', 
+  OverdraftCreated: 'OVERDRAFT_CREATED'
+});
+
+
+export type OverdraftApplicationStatus = $Values<typeof OverdraftApplicationStatusValues>;
+
+export type PageInfo = {|
+   __typename?: 'PageInfo',
+  startCursor?: ?$ElementType<Scalars, 'String'>,
+  endCursor?: ?$ElementType<Scalars, 'String'>,
+  hasNextPage: $ElementType<Scalars, 'Boolean'>,
+  hasPreviousPage: $ElementType<Scalars, 'Boolean'>,
+|};
+
+export const PaymentFrequencyValues = Object.freeze({
+  Monthly: 'MONTHLY', 
+  Quarterly: 'QUARTERLY', 
+  Yearly: 'YEARLY', 
+  None: 'NONE'
+});
+
+
+export type PaymentFrequency = $Values<typeof PaymentFrequencyValues>;
+
+export const PurchaseTypeValues = Object.freeze({
+  BasicInitial: 'BASIC_INITIAL', 
+  Basic: 'BASIC', 
+  Premium: 'PREMIUM', 
+  Card: 'CARD', 
+  Lexoffice: 'LEXOFFICE'
+});
+
+
+export type PurchaseType = $Values<typeof PurchaseTypeValues>;
+
+export type Query = {|
+   __typename?: 'Query',
+  /** The current user information */
+  viewer?: ?User,
+  status: SystemStatus,
+|};
+
+export const ScopeTypeValues = Object.freeze({
+  Offline: 'OFFLINE', 
+  Accounts: 'ACCOUNTS', 
+  Users: 'USERS', 
+  Transactions: 'TRANSACTIONS', 
+  Transfers: 'TRANSFERS', 
+  Subscriptions: 'SUBSCRIPTIONS', 
+  Statements: 'STATEMENTS', 
+  Admin: 'ADMIN', 
+  Clients: 'CLIENTS', 
+  Overdraft: 'OVERDRAFT'
+});
+
+
+export type ScopeType = $Values<typeof ScopeTypeValues>;
+
+export type SepaTransfer = {|
+   __typename?: 'SepaTransfer',
+  /** The status of the SEPA Transfer */
+  status: SepaTransferStatus,
+  /** The amount of the SEPA Transfer in cents */
+  amount: $ElementType<Scalars, 'Int'>,
+  /** The purpose of the SEPA Transfer - 140 max characters */
+  purpose?: ?$ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'String'>,
+  /** The name of the SEPA Transfer recipient */
+  recipient: $ElementType<Scalars, 'String'>,
+  /** The IBAN of the SEPA Transfer recipient */
+  iban: $ElementType<Scalars, 'String'>,
+  /** The end to end ID of the SEPA Transfer */
+  e2eId?: ?$ElementType<Scalars, 'String'>,
+|};
+
+export const SepaTransferStatusValues = Object.freeze({
+  Authorized: 'AUTHORIZED', 
+  Confirmed: 'CONFIRMED', 
+  Booked: 'BOOKED'
+});
+
+
+export type SepaTransferStatus = $Values<typeof SepaTransferStatusValues>;
+
+export const StandingOrderReoccurenceTypeValues = Object.freeze({
+  Monthly: 'MONTHLY', 
+  Quarterly: 'QUARTERLY', 
+  EverySixMonths: 'EVERY_SIX_MONTHS', 
+  Annually: 'ANNUALLY'
+});
+
+
+export type StandingOrderReoccurenceType = $Values<typeof StandingOrderReoccurenceTypeValues>;
+
+export const StatusValues = Object.freeze({
+  Error: 'ERROR'
+});
+
+
+export type Status = $Values<typeof StatusValues>;
+
+export type Subscription = {|
+   __typename?: 'Subscription',
+  newTransaction: Transaction,
+|};
+
+export type SystemStatus = {|
+   __typename?: 'SystemStatus',
+  type?: ?Status,
+  message?: ?$ElementType<Scalars, 'String'>,
+|};
+
+export type TaxYearSetting = {|
+   __typename?: 'TaxYearSetting',
+  /** Tax year the individual settings apply to */
+  year: $ElementType<Scalars, 'Int'>,
+  /** Tax rate that should be applied in the corresponding year */
+  taxRate?: ?$ElementType<Scalars, 'Int'>,
+  /** Flag if the corresponding year should be excluded from the tax calculations completely */
+  excluded?: ?$ElementType<Scalars, 'Boolean'>,
+|};
+
+export type TaxYearSettingInput = {|
+  /** Tax year the individual settings apply to */
+  year: $ElementType<Scalars, 'Int'>,
+  /** Tax rate that should be applied in the corresponding year */
+  taxRate?: ?$ElementType<Scalars, 'Int'>,
+  /** Flag if the corresponding year should be excluded from the tax calculations completely */
+  excluded?: ?$ElementType<Scalars, 'Boolean'>,
+|};
+
+export type Transaction = {|
+   __typename?: 'Transaction',
+  id: $ElementType<Scalars, 'ID'>,
+  /** The amount of the transaction in cents */
+  amount: $ElementType<Scalars, 'Int'>,
+  iban?: ?$ElementType<Scalars, 'String'>,
+  type: TransactionProjectionType,
+  /** The date at which the transaction was processed and the amount deducted from the user's account */
+  valutaDate?: ?$ElementType<Scalars, 'DateTime'>,
+  e2eId?: ?$ElementType<Scalars, 'String'>,
+  mandateNumber?: ?$ElementType<Scalars, 'String'>,
+  fees: Array<TransactionFee>,
+  /** Metadata of separate pseudo-transactions created when splitting the parent transaction */
+  splits: Array<TransactionSplit>,
+  /** The date at which the transaction was booked (created) */
+  bookingDate: $ElementType<Scalars, 'DateTime'>,
+  directDebitFees: Array<DirectDebitFee>,
+  name?: ?$ElementType<Scalars, 'String'>,
+  paymentMethod: $ElementType<Scalars, 'String'>,
+  category?: ?TransactionCategory,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+  purpose?: ?$ElementType<Scalars, 'String'>,
+  documentNumber?: ?$ElementType<Scalars, 'String'>,
+  documentPreviewUrl?: ?$ElementType<Scalars, 'String'>,
+  documentDownloadUrl?: ?$ElementType<Scalars, 'String'>,
+  documentType?: ?DocumentType,
+  foreignCurrency?: ?$ElementType<Scalars, 'String'>,
+  originalAmount?: ?$ElementType<Scalars, 'Int'>,
+|};
+
+export const TransactionCategoryValues = Object.freeze({
+  Private: 'PRIVATE', 
+  Vat: 'VAT', 
+  Vat_0: 'VAT_0', 
+  Vat_7: 'VAT_7', 
+  Vat_19: 'VAT_19', 
+  TaxPayment: 'TAX_PAYMENT', 
+  VatPayment: 'VAT_PAYMENT', 
+  TaxRefund: 'TAX_REFUND', 
+  VatRefund: 'VAT_REFUND', 
+  VatSaving: 'VAT_SAVING', 
+  TaxSaving: 'TAX_SAVING'
+});
+
+
+export type TransactionCategory = $Values<typeof TransactionCategoryValues>;
+
+export type TransactionCondition = {|
+  operator?: ?BaseOperator,
+  amount_lt?: ?$ElementType<Scalars, 'Int'>,
+  amount_gt?: ?$ElementType<Scalars, 'Int'>,
+  amount_gte?: ?$ElementType<Scalars, 'Int'>,
+  amount_lte?: ?$ElementType<Scalars, 'Int'>,
+  amount_eq?: ?$ElementType<Scalars, 'Int'>,
+  amount_ne?: ?$ElementType<Scalars, 'Int'>,
+  amount_in?: ?Array<$ElementType<Scalars, 'Int'>>,
+  iban_eq?: ?$ElementType<Scalars, 'String'>,
+  iban_ne?: ?$ElementType<Scalars, 'String'>,
+  iban_like?: ?$ElementType<Scalars, 'String'>,
+  iban_likeAny?: ?Array<$ElementType<Scalars, 'String'>>,
+  iban_in?: ?Array<$ElementType<Scalars, 'String'>>,
+  valutaDate_eq?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_ne?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_gt?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_lt?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_gte?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_lte?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_eq?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_ne?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_gt?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_lt?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_gte?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_lte?: ?$ElementType<Scalars, 'DateTime'>,
+  name_eq?: ?$ElementType<Scalars, 'String'>,
+  name_ne?: ?$ElementType<Scalars, 'String'>,
+  name_like?: ?$ElementType<Scalars, 'String'>,
+  name_likeAny?: ?Array<$ElementType<Scalars, 'String'>>,
+  name_in?: ?Array<$ElementType<Scalars, 'String'>>,
+  purpose_eq?: ?$ElementType<Scalars, 'String'>,
+  purpose_ne?: ?$ElementType<Scalars, 'String'>,
+  purpose_like?: ?$ElementType<Scalars, 'String'>,
+  purpose_likeAny?: ?Array<$ElementType<Scalars, 'String'>>,
+|};
+
+export type TransactionFee = {|
+   __typename?: 'TransactionFee',
+  type: TransactionFeeType,
+  status: TransactionFeeStatus,
+  unitAmount?: ?$ElementType<Scalars, 'Int'>,
+  usedAt?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+export const TransactionFeeStatusValues = Object.freeze({
+  Created: 'CREATED', 
+  Charged: 'CHARGED', 
+  Refunded: 'REFUNDED', 
+  Cancelled: 'CANCELLED', 
+  RefundInitiated: 'REFUND_INITIATED'
+});
+
+
+export type TransactionFeeStatus = $Values<typeof TransactionFeeStatusValues>;
+
+export const TransactionFeeTypeValues = Object.freeze({
+  Atm: 'ATM', 
+  ForeignTransaction: 'FOREIGN_TRANSACTION', 
+  DirectDebitReturn: 'DIRECT_DEBIT_RETURN', 
+  SecondReminderEmail: 'SECOND_REMINDER_EMAIL', 
+  CardReplacement: 'CARD_REPLACEMENT'
+});
+
+
+export type TransactionFeeType = $Values<typeof TransactionFeeTypeValues>;
+
+export type TransactionFilter = {|
+  operator?: ?BaseOperator,
+  amount_lt?: ?$ElementType<Scalars, 'Int'>,
+  amount_gt?: ?$ElementType<Scalars, 'Int'>,
+  amount_gte?: ?$ElementType<Scalars, 'Int'>,
+  amount_lte?: ?$ElementType<Scalars, 'Int'>,
+  amount_eq?: ?$ElementType<Scalars, 'Int'>,
+  amount_ne?: ?$ElementType<Scalars, 'Int'>,
+  amount_in?: ?Array<$ElementType<Scalars, 'Int'>>,
+  iban_eq?: ?$ElementType<Scalars, 'String'>,
+  iban_ne?: ?$ElementType<Scalars, 'String'>,
+  iban_like?: ?$ElementType<Scalars, 'String'>,
+  iban_likeAny?: ?Array<$ElementType<Scalars, 'String'>>,
+  iban_in?: ?Array<$ElementType<Scalars, 'String'>>,
+  valutaDate_eq?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_ne?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_gt?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_lt?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_gte?: ?$ElementType<Scalars, 'DateTime'>,
+  valutaDate_lte?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_eq?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_ne?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_gt?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_lt?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_gte?: ?$ElementType<Scalars, 'DateTime'>,
+  bookingDate_lte?: ?$ElementType<Scalars, 'DateTime'>,
+  name_eq?: ?$ElementType<Scalars, 'String'>,
+  name_ne?: ?$ElementType<Scalars, 'String'>,
+  name_like?: ?$ElementType<Scalars, 'String'>,
+  name_likeAny?: ?Array<$ElementType<Scalars, 'String'>>,
+  name_in?: ?Array<$ElementType<Scalars, 'String'>>,
+  purpose_eq?: ?$ElementType<Scalars, 'String'>,
+  purpose_ne?: ?$ElementType<Scalars, 'String'>,
+  purpose_like?: ?$ElementType<Scalars, 'String'>,
+  purpose_likeAny?: ?Array<$ElementType<Scalars, 'String'>>,
+  conditions?: ?Array<TransactionCondition>,
+|};
+
+export const TransactionProjectionTypeValues = Object.freeze({
+  CreditPresentment: 'CREDIT_PRESENTMENT', 
+  CashManual: 'CASH_MANUAL', 
+  Atm: 'ATM', 
+  CancelManualLoad: 'CANCEL_MANUAL_LOAD', 
+  CardUsage: 'CARD_USAGE', 
+  DirectDebitAutomaticTopup: 'DIRECT_DEBIT_AUTOMATIC_TOPUP', 
+  DirectDebitReturn: 'DIRECT_DEBIT_RETURN', 
+  DisputeClearing: 'DISPUTE_CLEARING', 
+  ManualLoad: 'MANUAL_LOAD', 
+  WireTransferTopup: 'WIRE_TRANSFER_TOPUP', 
+  TransferToBankAccount: 'TRANSFER_TO_BANK_ACCOUNT', 
+  CancellationBooking: 'CANCELLATION_BOOKING', 
+  CancellationDoubleBooking: 'CANCELLATION_DOUBLE_BOOKING', 
+  CreditTransferCancellation: 'CREDIT_TRANSFER_CANCELLATION', 
+  CurrencyTransactionCancellation: 'CURRENCY_TRANSACTION_CANCELLATION', 
+  DirectDebit: 'DIRECT_DEBIT', 
+  ForeignPayment: 'FOREIGN_PAYMENT', 
+  Other: 'OTHER', 
+  SepaCreditTransferReturn: 'SEPA_CREDIT_TRANSFER_RETURN', 
+  SepaCreditTransfer: 'SEPA_CREDIT_TRANSFER', 
+  SepaDirectDebitReturn: 'SEPA_DIRECT_DEBIT_RETURN', 
+  SepaDirectDebit: 'SEPA_DIRECT_DEBIT', 
+  Transfer: 'TRANSFER', 
+  InternationalCreditTransfer: 'INTERNATIONAL_CREDIT_TRANSFER', 
+  CancellationSepaDirectDebitReturn: 'CANCELLATION_SEPA_DIRECT_DEBIT_RETURN', 
+  Rebooking: 'REBOOKING', 
+  CancellationDirectDebit: 'CANCELLATION_DIRECT_DEBIT', 
+  CancellationSepaCreditTransferReturn: 'CANCELLATION_SEPA_CREDIT_TRANSFER_RETURN', 
+  CardTransaction: 'CARD_TRANSACTION', 
+  InterestAccrued: 'INTEREST_ACCRUED', 
+  CancellationInterestAccrued: 'CANCELLATION_INTEREST_ACCRUED'
+});
+
+
+export type TransactionProjectionType = $Values<typeof TransactionProjectionTypeValues>;
+
+export type TransactionsConnection = {|
+   __typename?: 'TransactionsConnection',
+  edges: Array<TransactionsConnectionEdge>,
+  pageInfo: PageInfo,
+|};
+
+export type TransactionsConnectionEdge = {|
+   __typename?: 'TransactionsConnectionEdge',
+  node: Transaction,
+  cursor: $ElementType<Scalars, 'String'>,
+|};
+
+export type TransactionSplit = {|
+   __typename?: 'TransactionSplit',
+  id: $ElementType<Scalars, 'ID'>,
+  amount: $ElementType<Scalars, 'Int'>,
+  category: TransactionCategory,
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+export type Transfer = {|
+   __typename?: 'Transfer',
+  id: $ElementType<Scalars, 'String'>,
+  /** The name of the transfer recipient */
+  recipient: $ElementType<Scalars, 'String'>,
+  /** The IBAN of the transfer recipient */
+  iban: $ElementType<Scalars, 'String'>,
+  /** The amount of the transfer in cents */
+  amount: $ElementType<Scalars, 'Int'>,
+  /** The status of the transfer */
+  status?: ?TransferStatus,
+  /** The date at which the payment will be executed for Timed Orders or Standing Orders */
+  executeAt?: ?$ElementType<Scalars, 'DateTime'>,
+  /** The date at which the last payment will be executed for Standing Orders */
+  lastExecutionDate?: ?$ElementType<Scalars, 'DateTime'>,
+  /** The purpose of the transfer - 140 max characters */
+  purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The end to end ID of the transfer */
+  e2eId?: ?$ElementType<Scalars, 'String'>,
+  /** The reoccurrence type of the payments for Standing Orders */
+  reoccurrence?: ?StandingOrderReoccurenceType,
+  /** The date at which the next payment will be executed for Standing Orders */
+  nextOccurrence?: ?$ElementType<Scalars, 'DateTime'>,
+  /** The user selected category for the SEPA Transfer */
+  category?: ?TransactionCategory,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+export type TransfersConnection = {|
+   __typename?: 'TransfersConnection',
+  edges: Array<TransfersConnectionEdge>,
+  pageInfo: PageInfo,
+|};
+
+export type TransfersConnectionEdge = {|
+   __typename?: 'TransfersConnectionEdge',
+  node: Transfer,
+  cursor: $ElementType<Scalars, 'String'>,
+|};
+
+export type TransfersConnectionFilter = {|
+  status?: ?TransferStatus,
+|};
+
+export const TransferStatusValues = Object.freeze({
+  Authorized: 'AUTHORIZED', 
+  Confirmed: 'CONFIRMED', 
+  Booked: 'BOOKED', 
+  Created: 'CREATED', 
+  Active: 'ACTIVE', 
+  Inactive: 'INACTIVE', 
+  Canceled: 'CANCELED', 
+  AuthorizationRequired: 'AUTHORIZATION_REQUIRED', 
+  ConfirmationRequired: 'CONFIRMATION_REQUIRED', 
+  Scheduled: 'SCHEDULED', 
+  Executed: 'EXECUTED', 
+  Failed: 'FAILED'
+});
+
+
+export type TransferStatus = $Values<typeof TransferStatusValues>;
+
+export type TransferSuggestion = {|
+   __typename?: 'TransferSuggestion',
+  iban: $ElementType<Scalars, 'String'>,
+  name: $ElementType<Scalars, 'String'>,
+|};
+
+export const TransferTypeValues = Object.freeze({
+  SepaTransfer: 'SEPA_TRANSFER', 
+  StandingOrder: 'STANDING_ORDER', 
+  TimedOrder: 'TIMED_ORDER'
+});
+
+
+export type TransferType = $Values<typeof TransferTypeValues>;
+
+/** The available fields to update an OAuth2 client */
+export type UpdateClientInput = {|
+  /** The name of the OAuth2 client displayed when users log in */
+  name?: ?$ElementType<Scalars, 'String'>,
+  /** The OAuth2 client secret */
+  secret?: ?$ElementType<Scalars, 'String'>,
+  /** The URL to redirect to after authentication */
+  redirectUri?: ?$ElementType<Scalars, 'String'>,
+  /** The grant types (i.e. ways to obtain access tokens) allowed for the client */
+  grantTypes?: ?Array<GrantType>,
+  /** The scopes the client has access to, limiting access to the corresponding parts of the API */
+  scopes?: ?Array<ScopeType>,
+  /** The id of the OAuth2 client to update */
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+export type UpdateSubscriptionPlanResult = {|
+   __typename?: 'UpdateSubscriptionPlanResult',
+  newPlan: $ElementType<Scalars, 'String'>,
+  previousPlans: Array<PurchaseType>,
+  hasOrderedPhysicalCard: $ElementType<Scalars, 'Boolean'>,
+  updateActiveAt: $ElementType<Scalars, 'String'>,
+  hasCanceledDowngrade: $ElementType<Scalars, 'Boolean'>,
+|};
+
+export type UpdateTransactionSplitsInput = {|
+  id: $ElementType<Scalars, 'Int'>,
+  amount: $ElementType<Scalars, 'Int'>,
+  category: TransactionCategory,
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+/** The available fields to update a transfer */
+export type UpdateTransferInput = {|
+  /** The ID of the transfer to update */
+  id: $ElementType<Scalars, 'String'>,
+  /** The type of transfer to update, currently only Standing Orders are supported */
+  type: TransferType,
+  /** The amount of the Standing Order payment in cents */
+  amount?: ?$ElementType<Scalars, 'Int'>,
+  /** The date at which the last payment will be executed */
+  lastExecutionDate?: ?$ElementType<Scalars, 'DateTime'>,
+  /** The purpose of the Standing Order - 140 max characters, if not specified with the update, it will be set to null */
+  purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The end to end ID of the Standing Order, if not specified with the update, it will be set to null */
+  e2eId?: ?$ElementType<Scalars, 'String'>,
+  /** The reoccurrence type of the payments for Standing Orders */
+  reoccurrence?: ?StandingOrderReoccurenceType,
+  /** The user selected category for the SEPA Transfer */
+  category?: ?TransactionCategory,
+  /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+|};
+
+export type User = {|
+   __typename?: 'User',
+  email: $ElementType<Scalars, 'String'>,
+  createdAt: $ElementType<Scalars, 'DateTime'>,
+  vatCutoffLine?: ?$ElementType<Scalars, 'DateTime'>,
+  taxCutoffLine?: ?$ElementType<Scalars, 'DateTime'>,
+  vatPaymentFrequency?: ?PaymentFrequency,
+  taxPaymentFrequency?: ?PaymentFrequency,
+  taxRate?: ?$ElementType<Scalars, 'Int'>,
+  vatRate?: ?$ElementType<Scalars, 'Int'>,
+  /** The user's IDNow identification status */
+  identificationStatus?: ?IdentificationStatus,
+  /** The link to use for IDNow identification */
+  identificationLink?: ?$ElementType<Scalars, 'String'>,
+  gender?: ?Gender,
+  firstName?: ?$ElementType<Scalars, 'String'>,
+  lastName?: ?$ElementType<Scalars, 'String'>,
+  birthPlace?: ?$ElementType<Scalars, 'String'>,
+  birthDate?: ?$ElementType<Scalars, 'DateTime'>,
+  nationality?: ?Nationality,
+  street?: ?$ElementType<Scalars, 'String'>,
+  postCode?: ?$ElementType<Scalars, 'String'>,
+  city?: ?$ElementType<Scalars, 'String'>,
+  mobileNumber?: ?$ElementType<Scalars, 'String'>,
+  untrustedPhoneNumber?: ?$ElementType<Scalars, 'String'>,
+  /** Indicates whether the user pays taxes in the US */
+  isUSPerson?: ?$ElementType<Scalars, 'Boolean'>,
+  companyType?: ?CompanyType,
+  publicId: $ElementType<Scalars, 'ID'>,
+  language?: ?$ElementType<Scalars, 'String'>,
+  country?: ?$ElementType<Scalars, 'String'>,
+  /** Business description provided by the user */
+  businessPurpose?: ?$ElementType<Scalars, 'String'>,
+  /** The economic sector of the user's business */
+  economicSector?: ?$ElementType<Scalars, 'String'>,
+  /** Business economic sector provided by the user */
+  otherEconomicSector?: ?$ElementType<Scalars, 'String'>,
+  vatNumber?: ?$ElementType<Scalars, 'String'>,
+  /** The user's referral code to use for promotional purposes */
+  referralCode?: ?$ElementType<Scalars, 'String'>,
+  /** The list of all OAuth2 clients for the current user */
+  clients: Array<Client>,
+  /** The details of an existing OAuth2 client */
+  client?: ?Client,
+  mainAccount?: ?Account,
+|};
+
+
+export type UserClientArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+|};
+
+export type WhitelistCardResponse = {|
+   __typename?: 'WhitelistCardResponse',
+  id: $ElementType<Scalars, 'String'>,
+  resolution: $ElementType<Scalars, 'String'>,
+  whitelisted_until: $ElementType<Scalars, 'String'>,
+|};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,6 +2433,12 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -3434,6 +3440,108 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "copy-webpack-plugin": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
+      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.3",
+        "find-cache-dir": "^2.1.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "minimatch": "^3.0.4",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "dev": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "dir-glob": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+          "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+          "dev": true,
+          "requires": {
+            "path-type": "^3.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
     },
     "core-js": {
       "version": "2.6.11",
@@ -10989,6 +11097,16 @@
             "yargs-parser": "^13.1.0"
           }
         }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
       }
     },
     "webpack-sources": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,8 +920,7 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -930,6 +929,14 @@
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
           }
         },
         "punycode": {
@@ -988,6 +995,231 @@
         "@graphql-toolkit/common": "0.6.6",
         "@graphql-toolkit/schema-merging": "0.6.6",
         "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/flow": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow/-/flow-1.13.3.tgz",
+      "integrity": "sha512-Zb20hv69GuhBETFZGiBP7vvd3Oyh4PVFN3HJEyCWpUxL3l8oQKWftc7rbDwtS+ScAId0GvNUOXkKfBU0OK3TXA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.13.3",
+        "@graphql-codegen/visitor-plugin-common": "1.13.3",
+        "auto-bind": "~4.0.0",
+        "tslib": "~1.11.1"
+      },
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.13.3.tgz",
+          "integrity": "sha512-ZBQFViP2KTpeIhFN69H4XlUYPnbTVFFdw0rZ8TMS50AvNoVd38B1OGlgXRTHuQBgs5digXdnkLH8mB6Gk2ElgA==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "~0.10.4",
+            "camel-case": "4.1.1",
+            "common-tags": "1.8.0",
+            "constant-case": "3.0.3",
+            "import-from": "3.0.0",
+            "lower-case": "2.0.1",
+            "param-case": "3.0.3",
+            "pascal-case": "3.1.1",
+            "tslib": "~1.11.1",
+            "upper-case": "2.0.1"
+          }
+        },
+        "@graphql-codegen/visitor-plugin-common": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.13.3.tgz",
+          "integrity": "sha512-+NBJva/jW22t6FLWlnSWXWk13tPZMLf9BHuM/iXxwF830ANvpRfd3s6sE8AGaTGM1Y8ciy9LCd3sDEcwU4shoQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-codegen/plugin-helpers": "1.13.3",
+            "@graphql-toolkit/relay-operation-optimizer": "~0.10.4",
+            "array.prototype.flatmap": "1.2.3",
+            "auto-bind": "~4.0.0",
+            "dependency-graph": "0.9.0",
+            "graphql-tag": "2.10.3",
+            "parse-filepath": "1.0.2",
+            "pascal-case": "3.1.1",
+            "tslib": "~1.11.1"
+          }
+        },
+        "@graphql-toolkit/common": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.10.4.tgz",
+          "integrity": "sha512-HQ3HaxCqX+UE8y/0h7LMDBBGSIKJxY/gaQesaksvE2Y+N4NpSWdiW6HpOcgXfC2HGf9yM0hEdsERzzL8z3mbHQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "3.0.1",
+            "camel-case": "4.1.1",
+            "graphql-tools": "5.0.0",
+            "lodash": "4.17.15"
+          }
+        },
+        "apollo-link": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+          "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+          "dev": true,
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.21"
+          }
+        },
+        "auto-bind": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+          "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+          "dev": true
+        },
+        "camel-case": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "constant-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.3.tgz",
+          "integrity": "sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.3",
+            "tslib": "^1.10.0",
+            "upper-case": "^2.0.1"
+          }
+        },
+        "dependency-graph": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.9.0.tgz",
+          "integrity": "sha512-9YLIBURXj4DJMFALxXw9K3Y3rwb5Fk0X5/8ipCzaN84+gKxoHK43tVKRNakCQbiEx07E8Uwhuq21BpUagFhZ8w==",
+          "dev": true
+        },
+        "dot-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+          "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "graphql-tag": {
+          "version": "2.10.3",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
+          "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==",
+          "dev": true
+        },
+        "graphql-tools": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
+          "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
+          "dev": true,
+          "requires": {
+            "apollo-link": "^1.2.14",
+            "apollo-upload-client": "^13.0.0",
+            "deprecated-decorator": "^0.1.6",
+            "form-data": "^3.0.0",
+            "iterall": "^1.3.0",
+            "node-fetch": "^2.6.0",
+            "tslib": "^1.11.1",
+            "uuid": "^7.0.3"
+          }
+        },
+        "iterall": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+          "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+          "dev": true
+        },
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "param-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+          "dev": true,
+          "requires": {
+            "dot-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+          "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+          "dev": true
+        },
+        "upper-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
+          "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
+        },
+        "zen-observable-ts": {
+          "version": "0.8.21",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
+          }
+        }
       }
     },
     "@graphql-codegen/plugin-helpers": {
@@ -1118,6 +1350,356 @@
       "dev": true,
       "requires": {
         "@graphql-toolkit/common": "0.6.6"
+      }
+    },
+    "@graphql-toolkit/relay-operation-optimizer": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/relay-operation-optimizer/-/relay-operation-optimizer-0.10.4.tgz",
+      "integrity": "sha512-fsklpeRt8ZdQRLQuKmU8Ag3AVlQVobg+7Mn54dHXHHViSh6R9i4Ez8ADDiOlnsa46mc5EyQex6bQzVcZHGRJdA==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.10.4",
+        "relay-compiler": "9.0.0"
+      },
+      "dependencies": {
+        "@graphql-toolkit/common": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.10.4.tgz",
+          "integrity": "sha512-HQ3HaxCqX+UE8y/0h7LMDBBGSIKJxY/gaQesaksvE2Y+N4NpSWdiW6HpOcgXfC2HGf9yM0hEdsERzzL8z3mbHQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "3.0.1",
+            "camel-case": "4.1.1",
+            "graphql-tools": "5.0.0",
+            "lodash": "4.17.15"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
+        },
+        "apollo-link": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+          "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+          "dev": true,
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.21"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "camel-case": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "graphql-tools": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
+          "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
+          "dev": true,
+          "requires": {
+            "apollo-link": "^1.2.14",
+            "apollo-upload-client": "^13.0.0",
+            "deprecated-decorator": "^0.1.6",
+            "form-data": "^3.0.0",
+            "iterall": "^1.3.0",
+            "node-fetch": "^2.6.0",
+            "tslib": "^1.11.1",
+            "uuid": "^7.0.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.11.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+              "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+              "dev": true
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "iterall": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+          "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+          "dev": true
+        },
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+          "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "relay-compiler": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-9.0.0.tgz",
+          "integrity": "sha512-V509bPZMqVvITUcgXFgvO9pcnAKzF7pJXObnxfglOl3JsfJeDwTW1fu/CzPtvk5suxVMK6Cn9fMxZK2GdRXqYQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "@babel/generator": "^7.5.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/runtime": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "babel-preset-fbjs": "^3.3.0",
+            "chalk": "^2.4.1",
+            "fast-glob": "^2.2.2",
+            "fb-watchman": "^2.0.0",
+            "fbjs": "^1.0.0",
+            "immutable": "~3.7.6",
+            "nullthrows": "^1.1.1",
+            "relay-runtime": "9.0.0",
+            "signedsource": "^1.0.0",
+            "yargs": "^14.2.0"
+          }
+        },
+        "relay-runtime": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-9.0.0.tgz",
+          "integrity": "sha512-bBNeNmwMOnqtCvuPnWdgflFSVwuUbGV7m7os8qHCUCSJ52DT5B/m6K4wisVh3eZ0QWYr7hheRDfmR/3UEdUe5A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "fbjs": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        },
+        "zen-observable-ts": {
+          "version": "0.8.21",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
+          }
+        }
       }
     },
     "@graphql-toolkit/schema-merging": {
@@ -1738,6 +2320,53 @@
         "zen-observable-ts": "^0.8.20"
       }
     },
+    "apollo-link-http-common": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+          "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+          "dev": true,
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.21"
+          }
+        },
+        "zen-observable-ts": {
+          "version": "0.8.21",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
+          }
+        }
+      }
+    },
+    "apollo-upload-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
+      "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "extract-files": "^8.0.0"
+      }
+    },
     "apollo-utilities": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
@@ -1809,6 +2438,17 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flatmap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz",
+      "integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
+      }
     },
     "asap": {
       "version": "2.0.6",
@@ -3586,6 +4226,12 @@
         }
       }
     },
+    "extract-files": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-8.1.0.tgz",
+      "integrity": "sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==",
+      "dev": true
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4653,6 +5299,16 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -4858,6 +5514,15 @@
         "has": "^1.0.3"
       }
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -4878,6 +5543,15 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
     },
     "is-upper-case": {
       "version": "1.1.2",
@@ -5919,7 +6593,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -6770,8 +7443,7 @@
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -6782,8 +7454,7 @@
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-      "dev": true
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
       "version": "2.2.1",
@@ -6867,6 +7538,17 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -6948,6 +7630,21 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-to-regexp": {
@@ -7610,10 +8307,8 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
           "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-          "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
             "p-is-promise": "^2.0.0"
           }
         },
@@ -7653,6 +8348,17 @@
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
+          },
+          "dependencies": {
+            "mem": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+              "dev": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            }
           }
         },
         "require-main-filename": {
@@ -9075,6 +9781,12 @@
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/sinon": "^7.5.2",
     "@types/ws": "^7.2.3",
     "chai": "^4.2.0",
+    "copy-webpack-plugin": "^5.1.1",
     "jsdom": "^16.2.1",
     "mocha": "^7.1.1",
     "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "1.8.3",
+    "@graphql-codegen/flow": "^1.13.3",
     "@graphql-codegen/typescript": "1.8.3",
     "@types/chai": "^4.2.11",
     "@types/jsdom": "^16.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: './dist/lib/index.js',
@@ -10,4 +11,9 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     library: 'Kontist'
   },
+  plugins: [
+    new CopyPlugin([
+      { from: './lib/graphql/schema.flow.js', to: './lib/graphql/schema.flow.js'}
+    ])
+  ]
 };


### PR DESCRIPTION
Let's expose flow types for our schema. It will be useful at least for our native app.

Thanks @johannespfeiffer for the suggestion to use graphql-codegen directly for this. Made it quite simple.

I'm not sure of the best approach to expose them though. So I have simply put them in the build next to the `schema.d.ts`.

It forces me to import them as "kontist/dist/lib/graphql/schema.flow" in the native app, but I'm doing so only once. I think this is OK, and I'm not sure there is a better way, considering our lib is written in typescript and not flow.