### PR TITLE
Add helper account stats 6852

### DIFF
--- a/lib/graphql/account.ts
+++ b/lib/graphql/account.ts
@@ -55,7 +55,7 @@ export class Account extends Model<AccountModel> {
    *
    * @returns current user account statistics
    */
-  public async getAccountStats(): Promise<AccountStats | null> {
+  public async getStats(): Promise<AccountStats | null> {
     const result: Query = await this.client.rawQuery(GET_ACCOUNT_STATS);
     return result.viewer?.mainAccount?.accountStats ?? null;
   }

--- a/lib/graphql/account.ts
+++ b/lib/graphql/account.ts
@@ -1,7 +1,7 @@
 import { KontistSDKError } from "../errors";
 import { Model } from "./model";
 import { ResultPage } from "./resultPage";
-import { Account as AccountModel, Query } from "./schema";
+import { Account as AccountModel, Query, AccountStats } from "./schema";
 
 const GET_ACCOUNT = `query {
   viewer {
@@ -13,10 +13,31 @@ const GET_ACCOUNT = `query {
     }
   }
 }`;
+const GET_ACCOUNT_STATS = `query {
+  viewer {
+    mainAccount {
+      accountStats {
+        accountBalance
+				main
+				yours
+				unknown
+      	vatAmount
+        vatTotal
+        vatMissing
+        taxCurrentYearAmount
+        taxPastYearAmount
+        taxTotal
+        taxMissing
+      }
+    }
+  }
+}`;
 
 export class Account extends Model<AccountModel> {
   public async fetch(): Promise<ResultPage<AccountModel>> {
-    throw new KontistSDKError({ message: "You are allowed only to fetch your account details." });
+    throw new KontistSDKError({
+      message: "You are allowed only to fetch your account details.",
+    });
   }
 
   /**
@@ -27,5 +48,15 @@ export class Account extends Model<AccountModel> {
   public async get(): Promise<AccountModel | null> {
     const result: Query = await this.client.rawQuery(GET_ACCOUNT);
     return result.viewer?.mainAccount || null;
+  }
+
+  /**
+   * Different statistics to the users account balance e.g. yours, unknow, vatTotal, taxMissing ...
+   *
+   * @returns current user account statistics
+   */
+  public async getAccountStats(): Promise<AccountStats | null> {
+    const result: Query = await this.client.rawQuery(GET_ACCOUNT_STATS);
+    return result.viewer?.mainAccount?.accountStats ?? null;
   }
 }

--- a/lib/graphql/account.ts
+++ b/lib/graphql/account.ts
@@ -18,10 +18,10 @@ const GET_ACCOUNT_STATS = `query {
     mainAccount {
       accountStats {
         accountBalance
-				main
-				yours
-				unknown
-      	vatAmount
+        main
+        yours
+        unknown
+        vatAmount
         vatTotal
         vatMissing
         taxCurrentYearAmount
@@ -51,12 +51,12 @@ export class Account extends Model<AccountModel> {
   }
 
   /**
-   * Different statistics to the users account balance e.g. yours, unknow, vatTotal, taxMissing ...
+   * Different statistics to the users account balance e.g. yours, unknown, vatTotal, taxMissing ...
    *
    * @returns current user account statistics
    */
   public async getStats(): Promise<AccountStats | null> {
     const result: Query = await this.client.rawQuery(GET_ACCOUNT_STATS);
-    return result.viewer?.mainAccount?.accountStats ?? null;
+    return result.viewer?.mainAccount?.stats ?? null;
   }
 }

--- a/lib/graphql/account.ts
+++ b/lib/graphql/account.ts
@@ -16,7 +16,7 @@ const GET_ACCOUNT = `query {
 const GET_ACCOUNT_STATS = `query {
   viewer {
     mainAccount {
-      accountStats {
+      stats {
         accountBalance
         main
         yours

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -23,6 +23,7 @@ export type Account = {|
   transaction?: ?Transaction,
   transactions: TransactionsConnection,
   transfer?: ?Transfer,
+  /** Different information about account balances, e.g. taxes, VAT, ... */
   accountStats?: ?AccountStats,
   /** Individual tax-related settings per year */
   taxYearSettings: Array<TaxYearSetting>,
@@ -79,16 +80,27 @@ export type AccountCardArgs = {|
 
 export type AccountStats = {|
    __typename?: 'AccountStats',
+  /** The amount that is currently available on the bank account */
   accountBalance: $ElementType<Scalars, 'Int'>,
-  main: $ElementType<Scalars, 'Int'>,
+  /** The amount that can be spend after VAT and taxes calculation */
   yours: $ElementType<Scalars, 'Int'>,
+  /** The amount that is not categorized */
   unknown: $ElementType<Scalars, 'Int'>,
-  vatAmount: $ElementType<Scalars, 'Int'>,
+  /** The amount that can be spend plus the amount from uknown */
+  main: $ElementType<Scalars, 'Int'>,
+  /** The amount of VAT that is owed (current + last years) */
   vatTotal: $ElementType<Scalars, 'Int'>,
+  /** The amount of VAT that is owed in the current year */
+  vatAmount: $ElementType<Scalars, 'Int'>,
+  /** The difference between vatTotal and accountBalance, if vatTotal > accountBalance */
   vatMissing: $ElementType<Scalars, 'Int'>,
-  taxCurrentYearAmount: $ElementType<Scalars, 'Int'>,
-  taxPastYearAmount?: ?$ElementType<Scalars, 'Int'>,
+  /** The amount of tax that is owed (Current + last years) */
   taxTotal: $ElementType<Scalars, 'Int'>,
+  /** The amount of tax that is owed in the current year */
+  taxCurrentYearAmount: $ElementType<Scalars, 'Int'>,
+  /** The amount of tax that was owed last year */
+  taxPastYearAmount?: ?$ElementType<Scalars, 'Int'>,
+  /** The difference between taxTotal and accountBalance, if taxTotal > accountbalance */
   taxMissing: $ElementType<Scalars, 'Int'>,
 |};
 

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -23,6 +23,7 @@ export type Account = {|
   transaction?: ?Transaction,
   transactions: TransactionsConnection,
   transfer?: ?Transfer,
+  accountStats?: ?AccountStats,
   /** Individual tax-related settings per year */
   taxYearSettings: Array<TaxYearSetting>,
   /**
@@ -34,11 +35,6 @@ export type Account = {|
   card?: ?Card,
   /** Overdraft Application - only available for Kontist Application */
   overdraft?: ?Overdraft,
-  /** 
-   * Different statistics to the users account balance
-   * e.g. yours, unknow, vatTotal, taxMissing ... 
-   */
-  accountStats?: ?AccountStats,
 |};
 
 
@@ -79,6 +75,21 @@ export type AccountTransferArgs = {|
 /** The bank account of the current user */
 export type AccountCardArgs = {|
   filter?: ?CardFilter,
+|};
+
+export type AccountStats = {|
+   __typename?: 'AccountStats',
+  accountBalance: $ElementType<Scalars, 'Int'>,
+  main: $ElementType<Scalars, 'Int'>,
+  yours: $ElementType<Scalars, 'Int'>,
+  unknown: $ElementType<Scalars, 'Int'>,
+  vatAmount: $ElementType<Scalars, 'Int'>,
+  vatTotal: $ElementType<Scalars, 'Int'>,
+  vatMissing: $ElementType<Scalars, 'Int'>,
+  taxCurrentYearAmount: $ElementType<Scalars, 'Int'>,
+  taxPastYearAmount?: ?$ElementType<Scalars, 'Int'>,
+  taxTotal: $ElementType<Scalars, 'Int'>,
+  taxMissing: $ElementType<Scalars, 'Int'>,
 |};
 
 export const BannerNameValues = Object.freeze({
@@ -1393,18 +1404,3 @@ export type WhitelistCardResponse = {|
   resolution: $ElementType<Scalars, 'String'>,
   whitelisted_until: $ElementType<Scalars, 'String'>,
 |};
-
-export type AccountStats = {|
-  /* TODO comment what those fields actually mean */
-  accountBalance: $ElementType<Scalars, 'Int'>,
-  main: $ElementType<Scalars, 'Int'>,
-  yours: $ElementType<Scalars, 'Int'>,
-  unknown: $ElementType<Scalars, 'Int'>,
-  vatAmount: $ElementType<Scalars, 'Int'>,
-  vatTotal: $ElementType<Scalars, 'Int'>,
-  vatMissing: $ElementType<Scalars, 'Int'>,
-  taxCurrentYearAmount: $ElementType<Scalars, 'Int'>,
-  taxPastYearAmount?:  ?$ElementType<Scalars, 'Int'>,
-  taxTotal: $ElementType<Scalars, 'Int'>,
-  taxMissing: $ElementType<Scalars, 'Int'>,
-  |}

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -24,7 +24,7 @@ export type Account = {|
   transactions: TransactionsConnection,
   transfer?: ?Transfer,
   /** Different information about account balances, e.g. taxes, VAT, ... */
-  accountStats?: ?AccountStats,
+  stats: AccountStats,
   /** Individual tax-related settings per year */
   taxYearSettings: Array<TaxYearSetting>,
   /**
@@ -82,11 +82,11 @@ export type AccountStats = {|
    __typename?: 'AccountStats',
   /** The amount that is currently available on the bank account */
   accountBalance: $ElementType<Scalars, 'Int'>,
-  /** The amount that can be spend after VAT and taxes calculation */
+  /** The amount that can be spent after VAT and taxes calculation */
   yours: $ElementType<Scalars, 'Int'>,
   /** The amount that is not categorized */
   unknown: $ElementType<Scalars, 'Int'>,
-  /** The amount that can be spend plus the amount from uknown */
+  /** The amount that can be spent plus the amount from uknown */
   main: $ElementType<Scalars, 'Int'>,
   /** The amount of VAT that is owed (current + last years) */
   vatTotal: $ElementType<Scalars, 'Int'>,
@@ -94,7 +94,7 @@ export type AccountStats = {|
   vatAmount: $ElementType<Scalars, 'Int'>,
   /** The difference between vatTotal and accountBalance, if vatTotal > accountBalance */
   vatMissing: $ElementType<Scalars, 'Int'>,
-  /** The amount of tax that is owed (Current + last years) */
+  /** The amount of tax that is owed (current + last years) */
   taxTotal: $ElementType<Scalars, 'Int'>,
   /** The amount of tax that is owed in the current year */
   taxCurrentYearAmount: $ElementType<Scalars, 'Int'>,

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -34,6 +34,11 @@ export type Account = {|
   card?: ?Card,
   /** Overdraft Application - only available for Kontist Application */
   overdraft?: ?Overdraft,
+  /** 
+   * Different statistics to the users account balance
+   * e.g. yours, unknow, vatTotal, taxMissing ... 
+   */
+  accountStats?: ?AccountStats,
 |};
 
 
@@ -1388,3 +1393,18 @@ export type WhitelistCardResponse = {|
   resolution: $ElementType<Scalars, 'String'>,
   whitelisted_until: $ElementType<Scalars, 'String'>,
 |};
+
+export type AccountStats = {|
+  /* TODO comment what those fields actually mean */
+  accountBalance: $ElementType<Scalars, 'Int'>,
+  main: $ElementType<Scalars, 'Int'>,
+  yours: $ElementType<Scalars, 'Int'>,
+  unknown: $ElementType<Scalars, 'Int'>,
+  vatAmount: $ElementType<Scalars, 'Int'>,
+  vatTotal: $ElementType<Scalars, 'Int'>,
+  vatMissing: $ElementType<Scalars, 'Int'>,
+  taxCurrentYearAmount: $ElementType<Scalars, 'Int'>,
+  taxPastYearAmount?:  ?$ElementType<Scalars, 'Int'>,
+  taxTotal: $ElementType<Scalars, 'Int'>,
+  taxMissing: $ElementType<Scalars, 'Int'>,
+  |}

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -32,6 +32,11 @@ export type Account = {
   card?: Maybe<Card>;
   /** Overdraft Application - only available for Kontist Application */
   overdraft?: Maybe<Overdraft>;
+  /** 
+   * Different statistics to the users account balance
+   *  e.g. yours, unknow, vatTotal, taxMissing ... 
+   */
+  accountStats: AccountStats;
 };
 
 
@@ -1308,3 +1313,19 @@ export type WhitelistCardResponse = {
   resolution: Scalars['String'];
   whitelisted_until: Scalars['String'];
 };
+
+export type AccountStats = {
+  // TODO comment what those fields actually mean
+  __typename?: 'AccountStats';
+  accountBalance: Scalars['Int'];
+  main: Scalars['Int'];
+  yours: Scalars['Int'];
+  unknown: Scalars['Int'];
+  vatAmount: Scalars['Int'];
+  vatTotal: Scalars['Int'];
+  vatMissing: Scalars['Int'];
+  taxCurrentYearAmount: Scalars['Int'];
+  taxPastYearAmount?: Maybe<Scalars['Int']>;
+  taxTotal: Scalars['Int'];
+  taxMissing: Scalars['Int'];
+}

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -21,6 +21,7 @@ export type Account = {
   transaction?: Maybe<Transaction>;
   transactions: TransactionsConnection;
   transfer?: Maybe<Transfer>;
+  accountStats?: Maybe<AccountStats>;
   /** Individual tax-related settings per year */
   taxYearSettings: Array<TaxYearSetting>;
   /**
@@ -32,11 +33,6 @@ export type Account = {
   card?: Maybe<Card>;
   /** Overdraft Application - only available for Kontist Application */
   overdraft?: Maybe<Overdraft>;
-  /** 
-   * Different statistics to the users account balance
-   *  e.g. yours, unknow, vatTotal, taxMissing ... 
-   */
-  accountStats: AccountStats;
 };
 
 
@@ -77,6 +73,21 @@ export type AccountTransferArgs = {
 /** The bank account of the current user */
 export type AccountCardArgs = {
   filter?: Maybe<CardFilter>;
+};
+
+export type AccountStats = {
+   __typename?: 'AccountStats';
+  accountBalance: Scalars['Int'];
+  main: Scalars['Int'];
+  yours: Scalars['Int'];
+  unknown: Scalars['Int'];
+  vatAmount: Scalars['Int'];
+  vatTotal: Scalars['Int'];
+  vatMissing: Scalars['Int'];
+  taxCurrentYearAmount: Scalars['Int'];
+  taxPastYearAmount?: Maybe<Scalars['Int']>;
+  taxTotal: Scalars['Int'];
+  taxMissing: Scalars['Int'];
 };
 
 export enum BannerName {
@@ -1313,19 +1324,3 @@ export type WhitelistCardResponse = {
   resolution: Scalars['String'];
   whitelisted_until: Scalars['String'];
 };
-
-export type AccountStats = {
-  // TODO comment what those fields actually mean
-  __typename?: 'AccountStats';
-  accountBalance: Scalars['Int'];
-  main: Scalars['Int'];
-  yours: Scalars['Int'];
-  unknown: Scalars['Int'];
-  vatAmount: Scalars['Int'];
-  vatTotal: Scalars['Int'];
-  vatMissing: Scalars['Int'];
-  taxCurrentYearAmount: Scalars['Int'];
-  taxPastYearAmount?: Maybe<Scalars['Int']>;
-  taxTotal: Scalars['Int'];
-  taxMissing: Scalars['Int'];
-}

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -22,7 +22,7 @@ export type Account = {
   transactions: TransactionsConnection;
   transfer?: Maybe<Transfer>;
   /** Different information about account balances, e.g. taxes, VAT, ... */
-  accountStats?: Maybe<AccountStats>;
+  stats: AccountStats;
   /** Individual tax-related settings per year */
   taxYearSettings: Array<TaxYearSetting>;
   /**
@@ -80,11 +80,11 @@ export type AccountStats = {
    __typename?: 'AccountStats';
   /** The amount that is currently available on the bank account */
   accountBalance: Scalars['Int'];
-  /** The amount that can be spend after VAT and taxes calculation */
+  /** The amount that can be spent after VAT and taxes calculation */
   yours: Scalars['Int'];
   /** The amount that is not categorized */
   unknown: Scalars['Int'];
-  /** The amount that can be spend plus the amount from uknown */
+  /** The amount that can be spent plus the amount from uknown */
   main: Scalars['Int'];
   /** The amount of VAT that is owed (current + last years) */
   vatTotal: Scalars['Int'];
@@ -92,7 +92,7 @@ export type AccountStats = {
   vatAmount: Scalars['Int'];
   /** The difference between vatTotal and accountBalance, if vatTotal > accountBalance */
   vatMissing: Scalars['Int'];
-  /** The amount of tax that is owed (Current + last years) */
+  /** The amount of tax that is owed (current + last years) */
   taxTotal: Scalars['Int'];
   /** The amount of tax that is owed in the current year */
   taxCurrentYearAmount: Scalars['Int'];

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -21,6 +21,7 @@ export type Account = {
   transaction?: Maybe<Transaction>;
   transactions: TransactionsConnection;
   transfer?: Maybe<Transfer>;
+  /** Different information about account balances, e.g. taxes, VAT, ... */
   accountStats?: Maybe<AccountStats>;
   /** Individual tax-related settings per year */
   taxYearSettings: Array<TaxYearSetting>;
@@ -77,16 +78,27 @@ export type AccountCardArgs = {
 
 export type AccountStats = {
    __typename?: 'AccountStats';
+  /** The amount that is currently available on the bank account */
   accountBalance: Scalars['Int'];
-  main: Scalars['Int'];
+  /** The amount that can be spend after VAT and taxes calculation */
   yours: Scalars['Int'];
+  /** The amount that is not categorized */
   unknown: Scalars['Int'];
-  vatAmount: Scalars['Int'];
+  /** The amount that can be spend plus the amount from uknown */
+  main: Scalars['Int'];
+  /** The amount of VAT that is owed (current + last years) */
   vatTotal: Scalars['Int'];
+  /** The amount of VAT that is owed in the current year */
+  vatAmount: Scalars['Int'];
+  /** The difference between vatTotal and accountBalance, if vatTotal > accountBalance */
   vatMissing: Scalars['Int'];
-  taxCurrentYearAmount: Scalars['Int'];
-  taxPastYearAmount?: Maybe<Scalars['Int']>;
+  /** The amount of tax that is owed (Current + last years) */
   taxTotal: Scalars['Int'];
+  /** The amount of tax that is owed in the current year */
+  taxCurrentYearAmount: Scalars['Int'];
+  /** The amount of tax that was owed last year */
+  taxPastYearAmount?: Maybe<Scalars['Int']>;
+  /** The difference between taxTotal and accountBalance, if taxTotal > accountbalance */
   taxMissing: Scalars['Int'];
 };
 

--- a/tests/graphql/account.spec.ts
+++ b/tests/graphql/account.spec.ts
@@ -101,7 +101,7 @@ describe("Account", () => {
       expect(result).to.eq(null);
     });
   });
-  describe("#getAccountStats", () => {
+  describe("#getStats", () => {
     it("should call rawQuery and return correct accountStats", async () => {
       // arrange
       const account = new Account(client.graphQL);
@@ -114,7 +114,7 @@ describe("Account", () => {
       } as any);
 
       // act
-      const result = await account.getAccountStats();
+      const result = await account.getStats();
 
       // assert
       sinon.assert.calledOnce(spyOnRawQuery);
@@ -129,7 +129,7 @@ describe("Account", () => {
       } as any);
 
       // act
-      const result = await account.getAccountStats();
+      const result = await account.getStats();
 
       // assert
       sinon.assert.calledOnce(spyOnRawQuery);

--- a/tests/graphql/account.spec.ts
+++ b/tests/graphql/account.spec.ts
@@ -5,6 +5,20 @@ import { Client } from "../../lib";
 import { KontistSDKError } from "../../lib/errors";
 import { Account } from "../../lib/graphql/account";
 
+const accountStatsData = {
+  accountBalance: 1378096,
+  main: 1189817,
+  yours: 1184262,
+  unknown: 5555,
+  vatAmount: -188279,
+  vatTotal: 188279,
+  vatMissing: 0,
+  taxCurrentYearAmount: 0,
+  taxPastYearAmount: null,
+  taxTotal: 0,
+  taxMissing: 0,
+}
+
 describe("Account", () => {
   let sandbox: sinon.SinonSandbox;
   let client: Client;
@@ -81,6 +95,41 @@ describe("Account", () => {
 
       // act
       const result = await account.get();
+
+      // assert
+      sinon.assert.calledOnce(spyOnRawQuery);
+      expect(result).to.eq(null);
+    });
+  });
+  describe("#getAccountStats", () => {
+    it("should call rawQuery and return correct accountStats", async () => {
+      // arrange
+      const account = new Account(client.graphQL);
+      const spyOnRawQuery = sandbox.stub(client.graphQL, "rawQuery").resolves({
+        viewer: {
+          mainAccount: {
+            accountStats: accountStatsData,
+          },
+        },
+      } as any);
+
+      // act
+      const result = await account.getAccountStats();
+
+      // assert
+      sinon.assert.calledOnce(spyOnRawQuery);
+      expect(result).to.deep.eq(accountStatsData);
+    });
+
+    it("should call rawQuery and return null for missing account", async () => {
+      // arrange
+      const account =  new Account(client.graphQL);
+      const spyOnRawQuery = sandbox.stub(client.graphQL, "rawQuery").resolves({
+        viewer: {},
+      } as any);
+
+      // act
+      const result = await account.getAccountStats();
 
       // assert
       sinon.assert.calledOnce(spyOnRawQuery);

--- a/tests/graphql/account.spec.ts
+++ b/tests/graphql/account.spec.ts
@@ -102,13 +102,13 @@ describe("Account", () => {
     });
   });
   describe("#getStats", () => {
-    it("should call rawQuery and return correct accountStats", async () => {
+    it("should call rawQuery and return correct stats", async () => {
       // arrange
       const account = new Account(client.graphQL);
       const spyOnRawQuery = sandbox.stub(client.graphQL, "rawQuery").resolves({
         viewer: {
           mainAccount: {
-            accountStats: accountStatsData,
+            stats: accountStatsData,
           },
         },
       } as any);


### PR DESCRIPTION
Addresses
https://app.zenhub.com/workspaces/kontist-engineering-5be06ab44b5806bc2bf14eca/issues/kontist/figure-backend/6852

Makes `account.getAccountStats()` available in the sdk.

Please make sure to have this BE running:
https://github.com/kontist/figure-backend/pull/6845