### PR TITLE
Remove redundant taxCutoffLine support

### DIFF
--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -14,7 +14,7 @@ export type Scalars = {|
 
 /** The bank account of the current user */
 export type Account = {|
-   __typename?: 'Account',
+  __typename?: 'Account',
   iban: $ElementType<Scalars, 'String'>,
   cardHolderRepresentation?: ?$ElementType<Scalars, 'String'>,
   balance: $ElementType<Scalars, 'Int'>,
@@ -94,7 +94,7 @@ export const AccountStateValues = Object.freeze({
 export type AccountState = $Values<typeof AccountStateValues>;
 
 export type AccountStats = {|
-   __typename?: 'AccountStats',
+  __typename?: 'AccountStats',
   /** The amount that is currently available on the bank account */
   accountBalance: $ElementType<Scalars, 'Int'>,
   /** The amount that can be spent after VAT and taxes calculation */
@@ -120,13 +120,13 @@ export type AccountStats = {|
 |};
 
 export type AvailableStatements = {|
-   __typename?: 'AvailableStatements',
+  __typename?: 'AvailableStatements',
   year: $ElementType<Scalars, 'Int'>,
   months: Array<$ElementType<Scalars, 'Int'>>,
 |};
 
 export type Banner = {|
-   __typename?: 'Banner',
+  __typename?: 'Banner',
   name: BannerName,
   dismissedAt?: ?$ElementType<Scalars, 'DateTime'>,
   isVisible: $ElementType<Scalars, 'Boolean'>,
@@ -150,7 +150,7 @@ export const BaseOperatorValues = Object.freeze({
 export type BaseOperator = $Values<typeof BaseOperatorValues>;
 
 export type BatchTransfer = {|
-   __typename?: 'BatchTransfer',
+  __typename?: 'BatchTransfer',
   id: $ElementType<Scalars, 'String'>,
   status: BatchTransferStatus,
   transfers: Array<SepaTransfer>,
@@ -168,7 +168,7 @@ export const BatchTransferStatusValues = Object.freeze({
 export type BatchTransferStatus = $Values<typeof BatchTransferStatusValues>;
 
 export type Card = {|
-   __typename?: 'Card',
+  __typename?: 'Card',
   id: $ElementType<Scalars, 'String'>,
   status: CardStatus,
   type: CardType,
@@ -195,7 +195,7 @@ export type CardFilter = {|
 |};
 
 export type CardLimit = {|
-   __typename?: 'CardLimit',
+  __typename?: 'CardLimit',
   maxAmountCents: $ElementType<Scalars, 'Float'>,
   maxTransactions: $ElementType<Scalars, 'Float'>,
 |};
@@ -206,7 +206,7 @@ export type CardLimitInput = {|
 |};
 
 export type CardLimits = {|
-   __typename?: 'CardLimits',
+  __typename?: 'CardLimits',
   daily: CardLimit,
   monthly: CardLimit,
 |};
@@ -229,7 +229,7 @@ export const CardMigrationStatusValues = Object.freeze({
 export type CardMigrationStatus = $Values<typeof CardMigrationStatusValues>;
 
 export type CardSettings = {|
-   __typename?: 'CardSettings',
+  __typename?: 'CardSettings',
   contactlessEnabled: $ElementType<Scalars, 'Boolean'>,
   cardPresentLimits?: ?CardLimits,
   cardNotPresentLimits?: ?CardLimits,
@@ -267,7 +267,7 @@ export const CardTypeValues = Object.freeze({
 export type CardType = $Values<typeof CardTypeValues>;
 
 export type Client = {|
-   __typename?: 'Client',
+  __typename?: 'Client',
   id: $ElementType<Scalars, 'ID'>,
   /** The URL to redirect to after authentication */
   redirectUri?: ?$ElementType<Scalars, 'String'>,
@@ -300,19 +300,19 @@ export const CompanyTypeValues = Object.freeze({
 export type CompanyType = $Values<typeof CompanyTypeValues>;
 
 export type ConfirmationRequest = {|
-   __typename?: 'ConfirmationRequest',
+  __typename?: 'ConfirmationRequest',
   confirmationId: $ElementType<Scalars, 'String'>,
 |};
 
 export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
 
 export type ConfirmationStatus = {|
-   __typename?: 'ConfirmationStatus',
+  __typename?: 'ConfirmationStatus',
   status: $ElementType<Scalars, 'String'>,
 |};
 
 export type ConfirmFraudResponse = {|
-   __typename?: 'ConfirmFraudResponse',
+  __typename?: 'ConfirmFraudResponse',
   id: $ElementType<Scalars, 'String'>,
   resolution: $ElementType<Scalars, 'String'>,
 |};
@@ -377,7 +377,7 @@ export type CreateTransferInput = {|
 
 
 export type DirectDebitFee = {|
-   __typename?: 'DirectDebitFee',
+  __typename?: 'DirectDebitFee',
   id: $ElementType<Scalars, 'Int'>,
   type: TransactionFeeType,
   name: $ElementType<Scalars, 'String'>,
@@ -403,7 +403,7 @@ export const GenderValues = Object.freeze({
 export type Gender = $Values<typeof GenderValues>;
 
 export type GooglePayCardToken = {|
-   __typename?: 'GooglePayCardToken',
+  __typename?: 'GooglePayCardToken',
   walletId: $ElementType<Scalars, 'String'>,
   tokenRefId: $ElementType<Scalars, 'String'>,
 |};
@@ -419,12 +419,12 @@ export const GrantTypeValues = Object.freeze({
 export type GrantType = $Values<typeof GrantTypeValues>;
 
 export type Icon = {|
-   __typename?: 'Icon',
+  __typename?: 'Icon',
   uri: $ElementType<Scalars, 'String'>,
 |};
 
 export type IdentificationDetails = {|
-   __typename?: 'IdentificationDetails',
+  __typename?: 'IdentificationDetails',
   /** The link to use for IDNow identification */
   link?: ?$ElementType<Scalars, 'String'>,
   /** The user's IDNow identification status */
@@ -468,14 +468,14 @@ export const InvoiceStatusValues = Object.freeze({
 export type InvoiceStatus = $Values<typeof InvoiceStatusValues>;
 
 export type Money = {|
-   __typename?: 'Money',
+  __typename?: 'Money',
   amount: $ElementType<Scalars, 'Int'>,
   fullAmount?: ?$ElementType<Scalars, 'Int'>,
   discountPercentage?: ?$ElementType<Scalars, 'Int'>,
 |};
 
 export type Mutation = {|
-   __typename?: 'Mutation',
+  __typename?: 'Mutation',
   /** Cancel an existing Timed Order or Standing Order */
   cancelTransfer: ConfirmationRequestOrTransfer,
   /** Confirm a Standing Order cancellation */
@@ -738,7 +738,7 @@ export type MutationUpdateUserNotificationsArgs = {|
 |};
 
 export type MutationResult = {|
-   __typename?: 'MutationResult',
+  __typename?: 'MutationResult',
   success: $ElementType<Scalars, 'Boolean'>,
 |};
 
@@ -997,7 +997,7 @@ export const NationalityValues = Object.freeze({
 export type Nationality = $Values<typeof NationalityValues>;
 
 export type Notification = {|
-   __typename?: 'Notification',
+  __typename?: 'Notification',
   type: NotificationType,
   active: $ElementType<Scalars, 'Boolean'>,
 |};
@@ -1015,7 +1015,7 @@ export const NotificationTypeValues = Object.freeze({
 export type NotificationType = $Values<typeof NotificationTypeValues>;
 
 export type Overdraft = {|
-   __typename?: 'Overdraft',
+  __typename?: 'Overdraft',
   id: $ElementType<Scalars, 'String'>,
   /** Overdraft status */
   status: OverdraftApplicationStatus,
@@ -1043,7 +1043,7 @@ export const OverdraftApplicationStatusValues = Object.freeze({
 export type OverdraftApplicationStatus = $Values<typeof OverdraftApplicationStatusValues>;
 
 export type PageInfo = {|
-   __typename?: 'PageInfo',
+  __typename?: 'PageInfo',
   startCursor?: ?$ElementType<Scalars, 'String'>,
   endCursor?: ?$ElementType<Scalars, 'String'>,
   hasNextPage: $ElementType<Scalars, 'Boolean'>,
@@ -1080,14 +1080,14 @@ export const PurchaseTypeValues = Object.freeze({
 export type PurchaseType = $Values<typeof PurchaseTypeValues>;
 
 export type Query = {|
-   __typename?: 'Query',
+  __typename?: 'Query',
   /** The current user information */
   viewer?: ?User,
   status: SystemStatus,
 |};
 
 export type ReferralDetails = {|
-   __typename?: 'ReferralDetails',
+  __typename?: 'ReferralDetails',
   code?: ?$ElementType<Scalars, 'String'>,
   link?: ?$ElementType<Scalars, 'String'>,
   /** Amount in euros granted to user and his referee */
@@ -1112,7 +1112,7 @@ export const ScopeTypeValues = Object.freeze({
 export type ScopeType = $Values<typeof ScopeTypeValues>;
 
 export type SepaTransfer = {|
-   __typename?: 'SepaTransfer',
+  __typename?: 'SepaTransfer',
   /** The status of the SEPA Transfer */
   status: SepaTransferStatus,
   /** The amount of the SEPA Transfer in cents */
@@ -1155,25 +1155,25 @@ export const StatusValues = Object.freeze({
 export type Status = $Values<typeof StatusValues>;
 
 export type Subscription = {|
-   __typename?: 'Subscription',
+  __typename?: 'Subscription',
   newTransaction: Transaction,
 |};
 
 export type SubscriptionFeature = {|
-   __typename?: 'SubscriptionFeature',
+  __typename?: 'SubscriptionFeature',
   title: $ElementType<Scalars, 'String'>,
   icon?: ?Icon,
 |};
 
 export type SubscriptionFeatureGroup = {|
-   __typename?: 'SubscriptionFeatureGroup',
+  __typename?: 'SubscriptionFeatureGroup',
   title?: ?$ElementType<Scalars, 'String'>,
   icon?: ?Icon,
   features: Array<SubscriptionFeature>,
 |};
 
 export type SubscriptionPlan = {|
-   __typename?: 'SubscriptionPlan',
+  __typename?: 'SubscriptionPlan',
   type: PurchaseType,
   subtitle?: ?$ElementType<Scalars, 'String'>,
   fee: Money,
@@ -1185,7 +1185,7 @@ export type SubscriptionPlan = {|
 |};
 
 export type SystemStatus = {|
-   __typename?: 'SystemStatus',
+  __typename?: 'SystemStatus',
   type?: ?Status,
   message?: ?$ElementType<Scalars, 'String'>,
 |};
@@ -1198,7 +1198,7 @@ export const TaxPaymentFrequencyValues = Object.freeze({
 export type TaxPaymentFrequency = $Values<typeof TaxPaymentFrequencyValues>;
 
 export type TaxYearSetting = {|
-   __typename?: 'TaxYearSetting',
+  __typename?: 'TaxYearSetting',
   /** Tax year the individual settings apply to */
   year: $ElementType<Scalars, 'Int'>,
   /** Tax rate that should be applied in the corresponding year */
@@ -1217,7 +1217,7 @@ export type TaxYearSettingInput = {|
 |};
 
 export type Transaction = {|
-   __typename?: 'Transaction',
+  __typename?: 'Transaction',
   id: $ElementType<Scalars, 'ID'>,
   /** The amount of the transaction in cents */
   amount: $ElementType<Scalars, 'Int'>,
@@ -1304,7 +1304,7 @@ export type TransactionCondition = {|
 |};
 
 export type TransactionFee = {|
-   __typename?: 'TransactionFee',
+  __typename?: 'TransactionFee',
   type: TransactionFeeType,
   status: TransactionFeeStatus,
   unitAmount?: ?$ElementType<Scalars, 'Int'>,
@@ -1409,19 +1409,19 @@ export const TransactionProjectionTypeValues = Object.freeze({
 export type TransactionProjectionType = $Values<typeof TransactionProjectionTypeValues>;
 
 export type TransactionsConnection = {|
-   __typename?: 'TransactionsConnection',
+  __typename?: 'TransactionsConnection',
   edges: Array<TransactionsConnectionEdge>,
   pageInfo: PageInfo,
 |};
 
 export type TransactionsConnectionEdge = {|
-   __typename?: 'TransactionsConnectionEdge',
+  __typename?: 'TransactionsConnectionEdge',
   node: Transaction,
   cursor: $ElementType<Scalars, 'String'>,
 |};
 
 export type TransactionSplit = {|
-   __typename?: 'TransactionSplit',
+  __typename?: 'TransactionSplit',
   id: $ElementType<Scalars, 'Int'>,
   amount: $ElementType<Scalars, 'Int'>,
   category: TransactionCategory,
@@ -1429,7 +1429,7 @@ export type TransactionSplit = {|
 |};
 
 export type Transfer = {|
-   __typename?: 'Transfer',
+  __typename?: 'Transfer',
   id: $ElementType<Scalars, 'String'>,
   /** The name of the transfer recipient */
   recipient: $ElementType<Scalars, 'String'>,
@@ -1458,13 +1458,13 @@ export type Transfer = {|
 |};
 
 export type TransfersConnection = {|
-   __typename?: 'TransfersConnection',
+  __typename?: 'TransfersConnection',
   edges: Array<TransfersConnectionEdge>,
   pageInfo: PageInfo,
 |};
 
 export type TransfersConnectionEdge = {|
-   __typename?: 'TransfersConnectionEdge',
+  __typename?: 'TransfersConnectionEdge',
   node: Transfer,
   cursor: $ElementType<Scalars, 'String'>,
 |};
@@ -1492,7 +1492,7 @@ export const TransferStatusValues = Object.freeze({
 export type TransferStatus = $Values<typeof TransferStatusValues>;
 
 export type TransferSuggestion = {|
-   __typename?: 'TransferSuggestion',
+  __typename?: 'TransferSuggestion',
   iban: $ElementType<Scalars, 'String'>,
   name: $ElementType<Scalars, 'String'>,
 |};
@@ -1523,7 +1523,7 @@ export type UpdateClientInput = {|
 |};
 
 export type UpdateSubscriptionPlanResult = {|
-   __typename?: 'UpdateSubscriptionPlanResult',
+  __typename?: 'UpdateSubscriptionPlanResult',
   newPlan: $ElementType<Scalars, 'String'>,
   previousPlans: Array<PurchaseType>,
   hasOrderedPhysicalCard: $ElementType<Scalars, 'Boolean'>,
@@ -1561,11 +1561,10 @@ export type UpdateTransferInput = {|
 |};
 
 export type User = {|
-   __typename?: 'User',
+  __typename?: 'User',
   email: $ElementType<Scalars, 'String'>,
   createdAt: $ElementType<Scalars, 'DateTime'>,
   vatCutoffLine?: ?$ElementType<Scalars, 'DateTime'>,
-  taxCutoffLine?: ?$ElementType<Scalars, 'DateTime'>,
   vatPaymentFrequency?: ?PaymentFrequency,
   taxPaymentFrequency?: ?TaxPaymentFrequency,
   taxRate?: ?$ElementType<Scalars, 'Int'>,
@@ -1646,14 +1645,14 @@ export type UserMetadataArgs = {|
 |};
 
 export type UserIntegration = {|
-   __typename?: 'UserIntegration',
+  __typename?: 'UserIntegration',
   type: IntegrationType,
   hasAccount: $ElementType<Scalars, 'Boolean'>,
   isConnected: $ElementType<Scalars, 'Boolean'>,
 |};
 
 export type UserMetadata = {|
-   __typename?: 'UserMetadata',
+  __typename?: 'UserMetadata',
   currentTermsAccepted: $ElementType<Scalars, 'Boolean'>,
   acceptedTermsVersion?: ?$ElementType<Scalars, 'String'>,
   /** List of months user can request a bank statement for */
@@ -1679,7 +1678,7 @@ export const UserOsValues = Object.freeze({
 export type UserOs = $Values<typeof UserOsValues>;
 
 export type UserSubscription = {|
-   __typename?: 'UserSubscription',
+  __typename?: 'UserSubscription',
   /** The type of the plans a user has subscribed to */
   type: PurchaseType,
   /** The state of the subscription */
@@ -1687,7 +1686,7 @@ export type UserSubscription = {|
 |};
 
 export type UserTaxDetails = {|
-   __typename?: 'UserTaxDetails',
+  __typename?: 'UserTaxDetails',
   adjustAdvancePayments: $ElementType<Scalars, 'Boolean'>,
   lastTaxPaymentDate?: ?$ElementType<Scalars, 'DateTime'>,
   lastVatPaymentDate?: ?$ElementType<Scalars, 'DateTime'>,
@@ -1701,7 +1700,7 @@ export type UserTaxDetails = {|
 |};
 
 export type WhitelistCardResponse = {|
-   __typename?: 'WhitelistCardResponse',
+  __typename?: 'WhitelistCardResponse',
   id: $ElementType<Scalars, 'String'>,
   resolution: $ElementType<Scalars, 'String'>,
   whitelisted_until: $ElementType<Scalars, 'String'>,
@@ -1717,7 +1716,7 @@ export const WirecardCardStatusValues = Object.freeze({
 export type WirecardCardStatus = $Values<typeof WirecardCardStatusValues>;
 
 export type WirecardDetails = {|
-   __typename?: 'WirecardDetails',
+  __typename?: 'WirecardDetails',
   cardStatus: WirecardCardStatus,
   directDebitMandateAccepted: $ElementType<Scalars, 'Boolean'>,
   hasAccount: $ElementType<Scalars, 'Boolean'>,

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -12,7 +12,7 @@ export type Scalars = {
 
 /** The bank account of the current user */
 export type Account = {
-   __typename?: 'Account';
+  __typename?: 'Account';
   iban: Scalars['String'];
   cardHolderRepresentation?: Maybe<Scalars['String']>;
   balance: Scalars['Int'];
@@ -92,7 +92,7 @@ export enum AccountState {
 }
 
 export type AccountStats = {
-   __typename?: 'AccountStats';
+  __typename?: 'AccountStats';
   /** The amount that is currently available on the bank account */
   accountBalance: Scalars['Int'];
   /** The amount that can be spent after VAT and taxes calculation */
@@ -118,13 +118,13 @@ export type AccountStats = {
 };
 
 export type AvailableStatements = {
-   __typename?: 'AvailableStatements';
+  __typename?: 'AvailableStatements';
   year: Scalars['Int'];
   months: Array<Scalars['Int']>;
 };
 
 export type Banner = {
-   __typename?: 'Banner';
+  __typename?: 'Banner';
   name: BannerName;
   dismissedAt?: Maybe<Scalars['DateTime']>;
   isVisible: Scalars['Boolean'];
@@ -142,7 +142,7 @@ export enum BaseOperator {
 }
 
 export type BatchTransfer = {
-   __typename?: 'BatchTransfer';
+  __typename?: 'BatchTransfer';
   id: Scalars['String'];
   status: BatchTransferStatus;
   transfers: Array<SepaTransfer>;
@@ -157,7 +157,7 @@ export enum BatchTransferStatus {
 }
 
 export type Card = {
-   __typename?: 'Card';
+  __typename?: 'Card';
   id: Scalars['String'];
   status: CardStatus;
   type: CardType;
@@ -181,7 +181,7 @@ export type CardFilter = {
 };
 
 export type CardLimit = {
-   __typename?: 'CardLimit';
+  __typename?: 'CardLimit';
   maxAmountCents: Scalars['Float'];
   maxTransactions: Scalars['Float'];
 };
@@ -192,7 +192,7 @@ export type CardLimitInput = {
 };
 
 export type CardLimits = {
-   __typename?: 'CardLimits';
+  __typename?: 'CardLimits';
   daily: CardLimit;
   monthly: CardLimit;
 };
@@ -212,7 +212,7 @@ export enum CardMigrationStatus {
 }
 
 export type CardSettings = {
-   __typename?: 'CardSettings';
+  __typename?: 'CardSettings';
   contactlessEnabled: Scalars['Boolean'];
   cardPresentLimits?: Maybe<CardLimits>;
   cardNotPresentLimits?: Maybe<CardLimits>;
@@ -244,7 +244,7 @@ export enum CardType {
 }
 
 export type Client = {
-   __typename?: 'Client';
+  __typename?: 'Client';
   id: Scalars['ID'];
   /** The URL to redirect to after authentication */
   redirectUri?: Maybe<Scalars['String']>;
@@ -274,19 +274,19 @@ export enum CompanyType {
 }
 
 export type ConfirmationRequest = {
-   __typename?: 'ConfirmationRequest';
+  __typename?: 'ConfirmationRequest';
   confirmationId: Scalars['String'];
 };
 
 export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
 
 export type ConfirmationStatus = {
-   __typename?: 'ConfirmationStatus';
+  __typename?: 'ConfirmationStatus';
   status: Scalars['String'];
 };
 
 export type ConfirmFraudResponse = {
-   __typename?: 'ConfirmFraudResponse';
+  __typename?: 'ConfirmFraudResponse';
   id: Scalars['String'];
   resolution: Scalars['String'];
 };
@@ -351,7 +351,7 @@ export type CreateTransferInput = {
 
 
 export type DirectDebitFee = {
-   __typename?: 'DirectDebitFee';
+  __typename?: 'DirectDebitFee';
   id: Scalars['Int'];
   type: TransactionFeeType;
   name: Scalars['String'];
@@ -371,7 +371,7 @@ export enum Gender {
 }
 
 export type GooglePayCardToken = {
-   __typename?: 'GooglePayCardToken';
+  __typename?: 'GooglePayCardToken';
   walletId: Scalars['String'];
   tokenRefId: Scalars['String'];
 };
@@ -384,12 +384,12 @@ export enum GrantType {
 }
 
 export type Icon = {
-   __typename?: 'Icon';
+  __typename?: 'Icon';
   uri: Scalars['String'];
 };
 
 export type IdentificationDetails = {
-   __typename?: 'IdentificationDetails';
+  __typename?: 'IdentificationDetails';
   /** The link to use for IDNow identification */
   link?: Maybe<Scalars['String']>;
   /** The user's IDNow identification status */
@@ -424,14 +424,14 @@ export enum InvoiceStatus {
 }
 
 export type Money = {
-   __typename?: 'Money';
+  __typename?: 'Money';
   amount: Scalars['Int'];
   fullAmount?: Maybe<Scalars['Int']>;
   discountPercentage?: Maybe<Scalars['Int']>;
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /** Cancel an existing Timed Order or Standing Order */
   cancelTransfer: ConfirmationRequestOrTransfer;
   /** Confirm a Standing Order cancellation */
@@ -694,7 +694,7 @@ export type MutationUpdateUserNotificationsArgs = {
 };
 
 export type MutationResult = {
-   __typename?: 'MutationResult';
+  __typename?: 'MutationResult';
   success: Scalars['Boolean'];
 };
 
@@ -950,7 +950,7 @@ export enum Nationality {
 }
 
 export type Notification = {
-   __typename?: 'Notification';
+  __typename?: 'Notification';
   type: NotificationType;
   active: Scalars['Boolean'];
 };
@@ -965,7 +965,7 @@ export enum NotificationType {
 }
 
 export type Overdraft = {
-   __typename?: 'Overdraft';
+  __typename?: 'Overdraft';
   id: Scalars['String'];
   /** Overdraft status */
   status: OverdraftApplicationStatus;
@@ -990,7 +990,7 @@ export enum OverdraftApplicationStatus {
 }
 
 export type PageInfo = {
-   __typename?: 'PageInfo';
+  __typename?: 'PageInfo';
   startCursor?: Maybe<Scalars['String']>;
   endCursor?: Maybe<Scalars['String']>;
   hasNextPage: Scalars['Boolean'];
@@ -1018,14 +1018,14 @@ export enum PurchaseType {
 }
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /** The current user information */
   viewer?: Maybe<User>;
   status: SystemStatus;
 };
 
 export type ReferralDetails = {
-   __typename?: 'ReferralDetails';
+  __typename?: 'ReferralDetails';
   code?: Maybe<Scalars['String']>;
   link?: Maybe<Scalars['String']>;
   /** Amount in euros granted to user and his referee */
@@ -1047,7 +1047,7 @@ export enum ScopeType {
 }
 
 export type SepaTransfer = {
-   __typename?: 'SepaTransfer';
+  __typename?: 'SepaTransfer';
   /** The status of the SEPA Transfer */
   status: SepaTransferStatus;
   /** The amount of the SEPA Transfer in cents */
@@ -1081,25 +1081,25 @@ export enum Status {
 }
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   newTransaction: Transaction;
 };
 
 export type SubscriptionFeature = {
-   __typename?: 'SubscriptionFeature';
+  __typename?: 'SubscriptionFeature';
   title: Scalars['String'];
   icon?: Maybe<Icon>;
 };
 
 export type SubscriptionFeatureGroup = {
-   __typename?: 'SubscriptionFeatureGroup';
+  __typename?: 'SubscriptionFeatureGroup';
   title?: Maybe<Scalars['String']>;
   icon?: Maybe<Icon>;
   features: Array<SubscriptionFeature>;
 };
 
 export type SubscriptionPlan = {
-   __typename?: 'SubscriptionPlan';
+  __typename?: 'SubscriptionPlan';
   type: PurchaseType;
   subtitle?: Maybe<Scalars['String']>;
   fee: Money;
@@ -1111,7 +1111,7 @@ export type SubscriptionPlan = {
 };
 
 export type SystemStatus = {
-   __typename?: 'SystemStatus';
+  __typename?: 'SystemStatus';
   type?: Maybe<Status>;
   message?: Maybe<Scalars['String']>;
 };
@@ -1121,7 +1121,7 @@ export enum TaxPaymentFrequency {
 }
 
 export type TaxYearSetting = {
-   __typename?: 'TaxYearSetting';
+  __typename?: 'TaxYearSetting';
   /** Tax year the individual settings apply to */
   year: Scalars['Int'];
   /** Tax rate that should be applied in the corresponding year */
@@ -1140,7 +1140,7 @@ export type TaxYearSettingInput = {
 };
 
 export type Transaction = {
-   __typename?: 'Transaction';
+  __typename?: 'Transaction';
   id: Scalars['ID'];
   /** The amount of the transaction in cents */
   amount: Scalars['Int'];
@@ -1224,7 +1224,7 @@ export type TransactionCondition = {
 };
 
 export type TransactionFee = {
-   __typename?: 'TransactionFee';
+  __typename?: 'TransactionFee';
   type: TransactionFeeType;
   status: TransactionFeeStatus;
   unitAmount?: Maybe<Scalars['Int']>;
@@ -1320,19 +1320,19 @@ export enum TransactionProjectionType {
 }
 
 export type TransactionsConnection = {
-   __typename?: 'TransactionsConnection';
+  __typename?: 'TransactionsConnection';
   edges: Array<TransactionsConnectionEdge>;
   pageInfo: PageInfo;
 };
 
 export type TransactionsConnectionEdge = {
-   __typename?: 'TransactionsConnectionEdge';
+  __typename?: 'TransactionsConnectionEdge';
   node: Transaction;
   cursor: Scalars['String'];
 };
 
 export type TransactionSplit = {
-   __typename?: 'TransactionSplit';
+  __typename?: 'TransactionSplit';
   id: Scalars['Int'];
   amount: Scalars['Int'];
   category: TransactionCategory;
@@ -1340,7 +1340,7 @@ export type TransactionSplit = {
 };
 
 export type Transfer = {
-   __typename?: 'Transfer';
+  __typename?: 'Transfer';
   id: Scalars['String'];
   /** The name of the transfer recipient */
   recipient: Scalars['String'];
@@ -1369,13 +1369,13 @@ export type Transfer = {
 };
 
 export type TransfersConnection = {
-   __typename?: 'TransfersConnection';
+  __typename?: 'TransfersConnection';
   edges: Array<TransfersConnectionEdge>;
   pageInfo: PageInfo;
 };
 
 export type TransfersConnectionEdge = {
-   __typename?: 'TransfersConnectionEdge';
+  __typename?: 'TransfersConnectionEdge';
   node: Transfer;
   cursor: Scalars['String'];
 };
@@ -1400,7 +1400,7 @@ export enum TransferStatus {
 }
 
 export type TransferSuggestion = {
-   __typename?: 'TransferSuggestion';
+  __typename?: 'TransferSuggestion';
   iban: Scalars['String'];
   name: Scalars['String'];
 };
@@ -1428,7 +1428,7 @@ export type UpdateClientInput = {
 };
 
 export type UpdateSubscriptionPlanResult = {
-   __typename?: 'UpdateSubscriptionPlanResult';
+  __typename?: 'UpdateSubscriptionPlanResult';
   newPlan: Scalars['String'];
   previousPlans: Array<PurchaseType>;
   hasOrderedPhysicalCard: Scalars['Boolean'];
@@ -1466,14 +1466,12 @@ export type UpdateTransferInput = {
 };
 
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   email: Scalars['String'];
   /** @deprecated This field will be removed in an upcoming release */
   createdAt: Scalars['DateTime'];
   /** @deprecated This field will be removed in an upcoming release */
   vatCutoffLine?: Maybe<Scalars['DateTime']>;
-  /** @deprecated This field will be removed in an upcoming release */
-  taxCutoffLine?: Maybe<Scalars['DateTime']>;
   /** @deprecated This field will be removed in an upcoming release and should now be queried from "viewer.taxDetails.vatPaymentFrequency" */
   vatPaymentFrequency?: Maybe<PaymentFrequency>;
   /** @deprecated This field will be removed in an upcoming release and should now be queried from "viewer.taxDetails.taxPaymentFrequency" */
@@ -1568,14 +1566,14 @@ export type UserMetadataArgs = {
 };
 
 export type UserIntegration = {
-   __typename?: 'UserIntegration';
+  __typename?: 'UserIntegration';
   type: IntegrationType;
   hasAccount: Scalars['Boolean'];
   isConnected: Scalars['Boolean'];
 };
 
 export type UserMetadata = {
-   __typename?: 'UserMetadata';
+  __typename?: 'UserMetadata';
   currentTermsAccepted: Scalars['Boolean'];
   acceptedTermsVersion?: Maybe<Scalars['String']>;
   /** List of months user can request a bank statement for */
@@ -1598,7 +1596,7 @@ export enum UserOs {
 }
 
 export type UserSubscription = {
-   __typename?: 'UserSubscription';
+  __typename?: 'UserSubscription';
   /** The type of the plans a user has subscribed to */
   type: PurchaseType;
   /** The state of the subscription */
@@ -1606,7 +1604,7 @@ export type UserSubscription = {
 };
 
 export type UserTaxDetails = {
-   __typename?: 'UserTaxDetails';
+  __typename?: 'UserTaxDetails';
   adjustAdvancePayments: Scalars['Boolean'];
   lastTaxPaymentDate?: Maybe<Scalars['DateTime']>;
   lastVatPaymentDate?: Maybe<Scalars['DateTime']>;
@@ -1621,7 +1619,7 @@ export type UserTaxDetails = {
 };
 
 export type WhitelistCardResponse = {
-   __typename?: 'WhitelistCardResponse';
+  __typename?: 'WhitelistCardResponse';
   id: Scalars['String'];
   resolution: Scalars['String'];
   whitelisted_until: Scalars['String'];
@@ -1634,7 +1632,7 @@ export enum WirecardCardStatus {
 }
 
 export type WirecardDetails = {
-   __typename?: 'WirecardDetails';
+  __typename?: 'WirecardDetails';
   cardStatus: WirecardCardStatus;
   directDebitMandateAccepted: Scalars['Boolean'];
   hasAccount: Scalars['Boolean'];

--- a/lib/graphql/user.ts
+++ b/lib/graphql/user.ts
@@ -27,7 +27,6 @@ const GET_USER = `query {
     publicId
     referralCode
     street
-    taxCutoffLine
     taxPaymentFrequency
     taxRate
     untrustedPhoneNumber


### PR DESCRIPTION
In order to remove the property from BE we have to remove it from the SDK first.

Corresponds to a ticket https://app.zenhub.com/workspaces/kontist-engineering-5be06ab44b5806bc2bf14eca/issues/kontist/figure-app/3581#issuecomment-629274380