### PR TITLE
Update schema with personal note

### DIFF
--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -119,12 +119,6 @@ export type AccountStats = {|
   taxMissing: $ElementType<Scalars, 'Int'>,
 |};
 
-export type AttributionData = {|
-  /** Platform used for signup */
-  platform?: ?Platform,
-  trackingId?: ?$ElementType<Scalars, 'String'>,
-|};
-
 export type AvailableStatements = {|
   __typename?: 'AvailableStatements',
   year: $ElementType<Scalars, 'Int'>,
@@ -385,15 +379,6 @@ export type CreateTransferInput = {|
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
 |};
 
-export type CreateUserInput = {|
-  /** User's email. This will be used as their username. */
-  email: $ElementType<Scalars, 'String'>,
-  password: $ElementType<Scalars, 'String'>,
-  language?: ?$ElementType<Scalars, 'String'>,
-  attribution?: ?AttributionData,
-  marketingConsentAccepted?: ?$ElementType<Scalars, 'Boolean'>,
-|};
-
 export type DirectDebitFee = {|
   __typename?: 'DirectDebitFee',
   id: $ElementType<Scalars, 'Int'>,
@@ -563,12 +548,6 @@ export type Mutation = {|
   /** Update user's subscription plan */
   updateSubscriptionPlan: UpdateSubscriptionPlanResult,
   dismissBanner: MutationResult,
-  /** Connect user to a bookkeeping partner */
-  connectIntegration: MutationResult,
-  /** Update user signup information */
-  updateUserSignupInformation: MutationResult,
-  /** Create a new user */
-  createUser: PublicMutationResult,
   /** Update the push-notifications a user should receive */
   updateUserNotifications: Array<Notification>,
 |};
@@ -762,23 +741,6 @@ export type MutationUpdateSubscriptionPlanArgs = {|
 export type MutationDismissBannerArgs = {|
   name: BannerName,
 |};
-
-
-export type MutationConnectIntegrationArgs = {|
-  type: IntegrationType,
-  authorizationData: $ElementType<Scalars, 'String'>,
-|};
-
-
-export type MutationUpdateUserSignupInformationArgs = {|
-  payload: UserUpdateInput,
-|};
-
-
-export type MutationCreateUserArgs = {|
-  payload: CreateUserInput,
-|};
-
 
 export type MutationUpdateUserNotificationsArgs = {|
   active: $ElementType<Scalars, 'Boolean'>,
@@ -1108,20 +1070,6 @@ export const PaymentFrequencyValues = Object.freeze({
 
 export type PaymentFrequency = $Values<typeof PaymentFrequencyValues>;
 
-export const PlatformValues = Object.freeze({
-  Ios: 'IOS',
-  Android: 'ANDROID',
-  Web: 'WEB'
-});
-
-
-export type Platform = $Values<typeof PlatformValues>;
-
-export type PublicMutationResult = {|
-  __typename?: 'PublicMutationResult',
-  success: $ElementType<Scalars, 'Boolean'>,
-|};
-
 export const PurchaseStateValues = Object.freeze({
   Processed: 'PROCESSED',
   Pending: 'PENDING'
@@ -1152,7 +1100,7 @@ export type ReferralDetails = {|
   __typename?: 'ReferralDetails',
   code?: ?$ElementType<Scalars, 'String'>,
   link?: ?$ElementType<Scalars, 'String'>,
-  /** Amount in euros granted to user and their referee */
+  /** Amount in euros granted to user and his referee */
   bonusAmount: $ElementType<Scalars, 'Int'>,
 |};
 
@@ -1708,7 +1656,7 @@ export type UserAvailablePlansArgs = {|
 
 
 export type UserMetadataArgs = {|
-  platform?: ?Platform,
+  os?: ?UserOs,
 |};
 
 export type UserIntegration = {|
@@ -1717,6 +1665,14 @@ export type UserIntegration = {|
   hasAccount: $ElementType<Scalars, 'Boolean'>,
   isConnected: $ElementType<Scalars, 'Boolean'>,
 |};
+
+export const UserOsValues = Object.freeze({
+  Ios: 'IOS',
+  Android: 'ANDROID'
+});
+
+
+export type UserOs = $Values<typeof UserOsValues>;
 
 export type UserMetadata = {|
   __typename?: 'UserMetadata',
@@ -1756,45 +1712,6 @@ export type UserTaxDetails = {|
   taxNumber?: ?$ElementType<Scalars, 'String'>,
   vatNumber?: ?$ElementType<Scalars, 'String'>,
   needsToProvideTaxIdentification: $ElementType<Scalars, 'Boolean'>,
-|};
-
-export type UserUpdateInput = {|
-  birthDate?: ?$ElementType<Scalars, 'DateTime'>,
-  city?: ?$ElementType<Scalars, 'String'>,
-  firstName?: ?$ElementType<Scalars, 'String'>,
-  lastName?: ?$ElementType<Scalars, 'String'>,
-  country?: ?Nationality,
-  nationality?: ?Nationality,
-  postCode?: ?$ElementType<Scalars, 'String'>,
-  street?: ?$ElementType<Scalars, 'String'>,
-  birthPlace?: ?$ElementType<Scalars, 'String'>,
-  /** Sets a mobile number for the user to be verified later */
-  untrustedPhoneNumber?: ?$ElementType<Scalars, 'String'>,
-  vatPaymentFrequency?: ?PaymentFrequency,
-  vatNumber?: ?$ElementType<Scalars, 'String'>,
-  vatRate?: ?$ElementType<Scalars, 'Int'>,
-  language?: ?$ElementType<Scalars, 'String'>,
-  /** Indicates whether the user pays taxes in the US */
-  isUSPerson?: ?$ElementType<Scalars, 'Boolean'>,
-  /** The version of terms user has accepted */
-  acceptedTermsVersion?: ?$ElementType<Scalars, 'String'>,
-  businessPurpose?: ?$ElementType<Scalars, 'String'>,
-  economicSector?: ?$ElementType<Scalars, 'String'>,
-  otherEconomicSector?: ?$ElementType<Scalars, 'String'>,
-  businessTradingName?: ?$ElementType<Scalars, 'String'>,
-  adjustAdvancePayments?: ?$ElementType<Scalars, 'Boolean'>,
-  companyType?: ?CompanyType,
-  /** Indicates user has accepted Kontist direct debit mandate */
-  directDebitMandateAccepted?: ?$ElementType<Scalars, 'Boolean'>,
-  /** Indicates user has confirmed he is opening their account in their name, for the use of their business */
-  ownEconomicInterestConfirmed?: ?$ElementType<Scalars, 'Boolean'>,
-  /** Indicates user has confirmed he is acting as a business and not a consumer */
-  nonConsumerConfirmed?: ?$ElementType<Scalars, 'Boolean'>,
-  /** Indicates user has accepted to receive Kontist marketing communication */
-  marketingConsentAccepted?: ?$ElementType<Scalars, 'Boolean'>,
-  /** Indicates user has accepted Wirecard direct debit mandate */
-  wirecardDirectDebitMandateAccepted?: ?$ElementType<Scalars, 'Boolean'>,
-  wirecardCardType?: ?$ElementType<Scalars, 'String'>,
 |};
 
 export type WhitelistCardResponse = {|

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -82,11 +82,11 @@ export type AccountCardArgs = {|
 |};
 
 export const AccountStateValues = Object.freeze({
-  Free: 'FREE', 
-  Trial: 'TRIAL', 
-  Premium: 'PREMIUM', 
-  Blocked: 'BLOCKED', 
-  FreeOld: 'FREE_OLD', 
+  Free: 'FREE',
+  Trial: 'TRIAL',
+  Premium: 'PREMIUM',
+  Blocked: 'BLOCKED',
+  FreeOld: 'FREE_OLD',
   PremiumOld: 'PREMIUM_OLD'
 });
 
@@ -119,6 +119,12 @@ export type AccountStats = {|
   taxMissing: $ElementType<Scalars, 'Int'>,
 |};
 
+export type AttributionData = {|
+  /** Platform used for signup */
+  platform?: ?Platform,
+  trackingId?: ?$ElementType<Scalars, 'String'>,
+|};
+
 export type AvailableStatements = {|
   __typename?: 'AvailableStatements',
   year: $ElementType<Scalars, 'Int'>,
@@ -133,8 +139,8 @@ export type Banner = {|
 |};
 
 export const BannerNameValues = Object.freeze({
-  Overdraft: 'OVERDRAFT', 
-  Bookkeeping: 'BOOKKEEPING', 
+  Overdraft: 'OVERDRAFT',
+  Bookkeeping: 'BOOKKEEPING',
   FriendReferral: 'FRIEND_REFERRAL'
 });
 
@@ -142,7 +148,7 @@ export const BannerNameValues = Object.freeze({
 export type BannerName = $Values<typeof BannerNameValues>;
 
 export const BaseOperatorValues = Object.freeze({
-  Or: 'OR', 
+  Or: 'OR',
   And: 'AND'
 });
 
@@ -157,10 +163,10 @@ export type BatchTransfer = {|
 |};
 
 export const BatchTransferStatusValues = Object.freeze({
-  AuthorizationRequired: 'AUTHORIZATION_REQUIRED', 
-  ConfirmationRequired: 'CONFIRMATION_REQUIRED', 
-  Accepted: 'ACCEPTED', 
-  Failed: 'FAILED', 
+  AuthorizationRequired: 'AUTHORIZATION_REQUIRED',
+  ConfirmationRequired: 'CONFIRMATION_REQUIRED',
+  Accepted: 'ACCEPTED',
+  Failed: 'FAILED',
   Successful: 'SUCCESSFUL'
 });
 
@@ -181,8 +187,8 @@ export type Card = {|
 |};
 
 export const CardActionValues = Object.freeze({
-  Close: 'CLOSE', 
-  Block: 'BLOCK', 
+  Close: 'CLOSE',
+  Block: 'BLOCK',
   Unblock: 'UNBLOCK'
 });
 
@@ -217,11 +223,11 @@ export type CardLimitsInput = {|
 |};
 
 export const CardMigrationStatusValues = Object.freeze({
-  Required: 'REQUIRED', 
-  Requested: 'REQUESTED', 
-  RequestedAndLocked: 'REQUESTED_AND_LOCKED', 
-  RequestedAndClosed: 'REQUESTED_AND_CLOSED', 
-  Completed: 'COMPLETED', 
+  Required: 'REQUIRED',
+  Requested: 'REQUESTED',
+  RequestedAndLocked: 'REQUESTED_AND_LOCKED',
+  RequestedAndClosed: 'REQUESTED_AND_CLOSED',
+  Completed: 'COMPLETED',
   NotRequired: 'NOT_REQUIRED'
 });
 
@@ -242,13 +248,13 @@ export type CardSettingsInput = {|
 |};
 
 export const CardStatusValues = Object.freeze({
-  Processing: 'PROCESSING', 
-  Inactive: 'INACTIVE', 
-  Active: 'ACTIVE', 
-  Blocked: 'BLOCKED', 
-  BlockedBySolaris: 'BLOCKED_BY_SOLARIS', 
-  ActivationBlockedBySolaris: 'ACTIVATION_BLOCKED_BY_SOLARIS', 
-  Closed: 'CLOSED', 
+  Processing: 'PROCESSING',
+  Inactive: 'INACTIVE',
+  Active: 'ACTIVE',
+  Blocked: 'BLOCKED',
+  BlockedBySolaris: 'BLOCKED_BY_SOLARIS',
+  ActivationBlockedBySolaris: 'ACTIVATION_BLOCKED_BY_SOLARIS',
+  Closed: 'CLOSED',
   ClosedBySolaris: 'CLOSED_BY_SOLARIS'
 });
 
@@ -256,10 +262,10 @@ export const CardStatusValues = Object.freeze({
 export type CardStatus = $Values<typeof CardStatusValues>;
 
 export const CardTypeValues = Object.freeze({
-  VirtualVisaBusinessDebit: 'VIRTUAL_VISA_BUSINESS_DEBIT', 
-  VisaBusinessDebit: 'VISA_BUSINESS_DEBIT', 
-  MastercardBusinessDebit: 'MASTERCARD_BUSINESS_DEBIT', 
-  VirtualMastercardBusinessDebit: 'VIRTUAL_MASTERCARD_BUSINESS_DEBIT', 
+  VirtualVisaBusinessDebit: 'VIRTUAL_VISA_BUSINESS_DEBIT',
+  VisaBusinessDebit: 'VISA_BUSINESS_DEBIT',
+  MastercardBusinessDebit: 'MASTERCARD_BUSINESS_DEBIT',
+  VirtualMastercardBusinessDebit: 'VIRTUAL_MASTERCARD_BUSINESS_DEBIT',
   VirtualVisaFreelanceDebit: 'VIRTUAL_VISA_FREELANCE_DEBIT'
 });
 
@@ -280,19 +286,19 @@ export type Client = {|
 |};
 
 export const CompanyTypeValues = Object.freeze({
-  Selbstaendig: 'SELBSTAENDIG', 
-  Einzelunternehmer: 'EINZELUNTERNEHMER', 
-  Freiberufler: 'FREIBERUFLER', 
-  Gewerbetreibender: 'GEWERBETREIBENDER', 
-  Limited: 'LIMITED', 
-  EK: 'E_K', 
-  Partgg: 'PARTGG', 
-  Gbr: 'GBR', 
-  Ohg: 'OHG', 
-  Kg: 'KG', 
-  Kgaa: 'KGAA', 
-  Gmbh: 'GMBH', 
-  GmbhUndCoKg: 'GMBH_UND_CO_KG', 
+  Selbstaendig: 'SELBSTAENDIG',
+  Einzelunternehmer: 'EINZELUNTERNEHMER',
+  Freiberufler: 'FREIBERUFLER',
+  Gewerbetreibender: 'GEWERBETREIBENDER',
+  Limited: 'LIMITED',
+  EK: 'E_K',
+  Partgg: 'PARTGG',
+  Gbr: 'GBR',
+  Ohg: 'OHG',
+  Kg: 'KG',
+  Kgaa: 'KGAA',
+  Gmbh: 'GMBH',
+  GmbhUndCoKg: 'GMBH_UND_CO_KG',
   Ug: 'UG'
 });
 
@@ -341,6 +347,8 @@ export type CreateSepaTransferInput = {|
   amount: $ElementType<Scalars, 'Int'>,
   /** The purpose of the SEPA Transfer - 140 max characters */
   purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The personal note of the SEPA Transfer - 140 max characters */
+  personalNote?: ?$ElementType<Scalars, 'String'>,
   /** The end to end ID of the SEPA Transfer */
   e2eId?: ?$ElementType<Scalars, 'String'>,
 |};
@@ -365,6 +373,8 @@ export type CreateTransferInput = {|
   lastExecutionDate?: ?$ElementType<Scalars, 'DateTime'>,
   /** The purpose of the transfer - 140 max characters */
   purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The personal note of the transfer - 140 max characters */
+  personalNote?: ?$ElementType<Scalars, 'String'>,
   /** The end to end ID of the transfer */
   e2eId?: ?$ElementType<Scalars, 'String'>,
   /** The reoccurrence type of the payments for Standing Orders */
@@ -375,6 +385,14 @@ export type CreateTransferInput = {|
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
 |};
 
+export type CreateUserInput = {|
+  /** User's email. This will be used as their username. */
+  email: $ElementType<Scalars, 'String'>,
+  password: $ElementType<Scalars, 'String'>,
+  language?: ?$ElementType<Scalars, 'String'>,
+  attribution?: ?AttributionData,
+  marketingConsentAccepted?: ?$ElementType<Scalars, 'Boolean'>,
+|};
 
 export type DirectDebitFee = {|
   __typename?: 'DirectDebitFee',
@@ -387,7 +405,7 @@ export type DirectDebitFee = {|
 |};
 
 export const DocumentTypeValues = Object.freeze({
-  Voucher: 'VOUCHER', 
+  Voucher: 'VOUCHER',
   Invoice: 'INVOICE'
 });
 
@@ -395,7 +413,7 @@ export const DocumentTypeValues = Object.freeze({
 export type DocumentType = $Values<typeof DocumentTypeValues>;
 
 export const GenderValues = Object.freeze({
-  Male: 'MALE', 
+  Male: 'MALE',
   Female: 'FEMALE'
 });
 
@@ -409,9 +427,9 @@ export type GooglePayCardToken = {|
 |};
 
 export const GrantTypeValues = Object.freeze({
-  Password: 'PASSWORD', 
-  AuthorizationCode: 'AUTHORIZATION_CODE', 
-  RefreshToken: 'REFRESH_TOKEN', 
+  Password: 'PASSWORD',
+  AuthorizationCode: 'AUTHORIZATION_CODE',
+  RefreshToken: 'REFRESH_TOKEN',
   ClientCredentials: 'CLIENT_CREDENTIALS'
 });
 
@@ -434,14 +452,14 @@ export type IdentificationDetails = {|
 |};
 
 export const IdentificationStatusValues = Object.freeze({
-  Pending: 'PENDING', 
-  PendingSuccessful: 'PENDING_SUCCESSFUL', 
-  PendingFailed: 'PENDING_FAILED', 
-  Successful: 'SUCCESSFUL', 
-  Failed: 'FAILED', 
-  Expired: 'EXPIRED', 
-  Created: 'CREATED', 
-  Aborted: 'ABORTED', 
+  Pending: 'PENDING',
+  PendingSuccessful: 'PENDING_SUCCESSFUL',
+  PendingFailed: 'PENDING_FAILED',
+  Successful: 'SUCCESSFUL',
+  Failed: 'FAILED',
+  Expired: 'EXPIRED',
+  Created: 'CREATED',
+  Aborted: 'ABORTED',
   Canceled: 'CANCELED'
 });
 
@@ -449,8 +467,8 @@ export const IdentificationStatusValues = Object.freeze({
 export type IdentificationStatus = $Values<typeof IdentificationStatusValues>;
 
 export const IntegrationTypeValues = Object.freeze({
-  Lexoffice: 'LEXOFFICE', 
-  Debitoor: 'DEBITOOR', 
+  Lexoffice: 'LEXOFFICE',
+  Debitoor: 'DEBITOOR',
   Fastbill: 'FASTBILL'
 });
 
@@ -458,9 +476,9 @@ export const IntegrationTypeValues = Object.freeze({
 export type IntegrationType = $Values<typeof IntegrationTypeValues>;
 
 export const InvoiceStatusValues = Object.freeze({
-  Open: 'OPEN', 
-  Closed: 'CLOSED', 
-  Rejected: 'REJECTED', 
+  Open: 'OPEN',
+  Closed: 'CLOSED',
+  Rejected: 'REJECTED',
   Pending: 'PENDING'
 });
 
@@ -523,6 +541,8 @@ export type Mutation = {|
   setCardHolderRepresentation: $ElementType<Scalars, 'String'>,
   /** Categorize a transaction with an optional custom booking date for VAT or Tax categories */
   categorizeTransaction: Transaction,
+  /** Update a transaction with a category (with an optional custom booking date for VAT or Tax categories) and/or a personal note */
+  updateTransaction: Transaction,
   /** Create Overdraft Application  - only available for Kontist Application */
   requestOverdraft?: ?Overdraft,
   /** Activate Overdraft Application  - only available for Kontist Application */
@@ -543,6 +563,12 @@ export type Mutation = {|
   /** Update user's subscription plan */
   updateSubscriptionPlan: UpdateSubscriptionPlanResult,
   dismissBanner: MutationResult,
+  /** Connect user to a bookkeeping partner */
+  connectIntegration: MutationResult,
+  /** Update user signup information */
+  updateUserSignupInformation: MutationResult,
+  /** Create a new user */
+  createUser: PublicMutationResult,
   /** Update the push-notifications a user should receive */
   updateUserNotifications: Array<Notification>,
 |};
@@ -692,6 +718,12 @@ export type MutationCategorizeTransactionArgs = {|
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
 |};
 
+export type MutationUpdateTransactionArgs = {|
+  id: $ElementType<Scalars, 'String'>,
+  category?: ?TransactionCategory,
+  userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+  personalNote?: string,
+|}
 
 export type MutationUpdateOverdraftArgs = {|
   offeredScreenShown?: ?$ElementType<Scalars, 'Boolean'>,
@@ -732,6 +764,22 @@ export type MutationDismissBannerArgs = {|
 |};
 
 
+export type MutationConnectIntegrationArgs = {|
+  type: IntegrationType,
+  authorizationData: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationUpdateUserSignupInformationArgs = {|
+  payload: UserUpdateInput,
+|};
+
+
+export type MutationCreateUserArgs = {|
+  payload: CreateUserInput,
+|};
+
+
 export type MutationUpdateUserNotificationsArgs = {|
   active: $ElementType<Scalars, 'Boolean'>,
   type: NotificationType,
@@ -743,253 +791,253 @@ export type MutationResult = {|
 |};
 
 export const NationalityValues = Object.freeze({
-  De: 'DE', 
-  Ad: 'AD', 
-  Ae: 'AE', 
-  Af: 'AF', 
-  Ag: 'AG', 
-  Ai: 'AI', 
-  Al: 'AL', 
-  Am: 'AM', 
-  Ao: 'AO', 
-  Aq: 'AQ', 
-  Ar: 'AR', 
-  As: 'AS', 
-  At: 'AT', 
-  Au: 'AU', 
-  Aw: 'AW', 
-  Ax: 'AX', 
-  Az: 'AZ', 
-  Ba: 'BA', 
-  Bb: 'BB', 
-  Bd: 'BD', 
-  Be: 'BE', 
-  Bf: 'BF', 
-  Bg: 'BG', 
-  Bh: 'BH', 
-  Bi: 'BI', 
-  Bj: 'BJ', 
-  Bl: 'BL', 
-  Bm: 'BM', 
-  Bn: 'BN', 
-  Bo: 'BO', 
-  Br: 'BR', 
-  Bs: 'BS', 
-  Bt: 'BT', 
-  Bv: 'BV', 
-  Bw: 'BW', 
-  By: 'BY', 
-  Bz: 'BZ', 
-  Ca: 'CA', 
-  Cc: 'CC', 
-  Cd: 'CD', 
-  Cf: 'CF', 
-  Cg: 'CG', 
-  Ch: 'CH', 
-  Ci: 'CI', 
-  Ck: 'CK', 
-  Cl: 'CL', 
-  Cm: 'CM', 
-  Cn: 'CN', 
-  Co: 'CO', 
-  Cr: 'CR', 
-  Cu: 'CU', 
-  Cv: 'CV', 
-  Cw: 'CW', 
-  Cx: 'CX', 
-  Cy: 'CY', 
-  Cz: 'CZ', 
-  Dj: 'DJ', 
-  Dk: 'DK', 
-  Dm: 'DM', 
-  Do: 'DO', 
-  Dz: 'DZ', 
-  Ec: 'EC', 
-  Ee: 'EE', 
-  Eg: 'EG', 
-  Eh: 'EH', 
-  Er: 'ER', 
-  Es: 'ES', 
-  Et: 'ET', 
-  Fi: 'FI', 
-  Fj: 'FJ', 
-  Fk: 'FK', 
-  Fm: 'FM', 
-  Fo: 'FO', 
-  Fr: 'FR', 
-  Ga: 'GA', 
-  Gb: 'GB', 
-  Gd: 'GD', 
-  Ge: 'GE', 
-  Gf: 'GF', 
-  Gg: 'GG', 
-  Gh: 'GH', 
-  Gi: 'GI', 
-  Gl: 'GL', 
-  Gm: 'GM', 
-  Gn: 'GN', 
-  Gp: 'GP', 
-  Gq: 'GQ', 
-  Gr: 'GR', 
-  Gs: 'GS', 
-  Gt: 'GT', 
-  Gu: 'GU', 
-  Gw: 'GW', 
-  Gy: 'GY', 
-  Hk: 'HK', 
-  Hm: 'HM', 
-  Hn: 'HN', 
-  Hr: 'HR', 
-  Ht: 'HT', 
-  Hu: 'HU', 
-  Id: 'ID', 
-  Ie: 'IE', 
-  Il: 'IL', 
-  Im: 'IM', 
-  In: 'IN', 
-  Io: 'IO', 
-  Iq: 'IQ', 
-  Ir: 'IR', 
-  Is: 'IS', 
-  It: 'IT', 
-  Je: 'JE', 
-  Jm: 'JM', 
-  Jo: 'JO', 
-  Jp: 'JP', 
-  Ke: 'KE', 
-  Kg: 'KG', 
-  Kh: 'KH', 
-  Ki: 'KI', 
-  Km: 'KM', 
-  Kn: 'KN', 
-  Kp: 'KP', 
-  Kr: 'KR', 
-  Kw: 'KW', 
-  Ky: 'KY', 
-  Kz: 'KZ', 
-  La: 'LA', 
-  Lb: 'LB', 
-  Lc: 'LC', 
-  Li: 'LI', 
-  Lk: 'LK', 
-  Lr: 'LR', 
-  Ls: 'LS', 
-  Lt: 'LT', 
-  Lu: 'LU', 
-  Lv: 'LV', 
-  Ly: 'LY', 
-  Ma: 'MA', 
-  Mc: 'MC', 
-  Md: 'MD', 
-  Me: 'ME', 
-  Mf: 'MF', 
-  Mg: 'MG', 
-  Mh: 'MH', 
-  Mk: 'MK', 
-  Ml: 'ML', 
-  Mm: 'MM', 
-  Mn: 'MN', 
-  Mo: 'MO', 
-  Mp: 'MP', 
-  Mq: 'MQ', 
-  Mr: 'MR', 
-  Ms: 'MS', 
-  Mt: 'MT', 
-  Mu: 'MU', 
-  Mv: 'MV', 
-  Mw: 'MW', 
-  Mx: 'MX', 
-  My: 'MY', 
-  Mz: 'MZ', 
-  Na: 'NA', 
-  Nc: 'NC', 
-  Ne: 'NE', 
-  Nf: 'NF', 
-  Ng: 'NG', 
-  Ni: 'NI', 
-  Nl: 'NL', 
-  No: 'NO', 
-  Np: 'NP', 
-  Nr: 'NR', 
-  Nu: 'NU', 
-  Nz: 'NZ', 
-  Om: 'OM', 
-  Pa: 'PA', 
-  Pe: 'PE', 
-  Pf: 'PF', 
-  Pg: 'PG', 
-  Ph: 'PH', 
-  Pk: 'PK', 
-  Pl: 'PL', 
-  Pm: 'PM', 
-  Pn: 'PN', 
-  Pr: 'PR', 
-  Ps: 'PS', 
-  Pt: 'PT', 
-  Pw: 'PW', 
-  Py: 'PY', 
-  Qa: 'QA', 
-  Re: 'RE', 
-  Ro: 'RO', 
-  Rs: 'RS', 
-  Ru: 'RU', 
-  Rw: 'RW', 
-  Sa: 'SA', 
-  Sb: 'SB', 
-  Sc: 'SC', 
-  Sd: 'SD', 
-  Se: 'SE', 
-  Sg: 'SG', 
-  Si: 'SI', 
-  Sj: 'SJ', 
-  Sk: 'SK', 
-  Sl: 'SL', 
-  Sm: 'SM', 
-  Sn: 'SN', 
-  So: 'SO', 
-  Sr: 'SR', 
-  Ss: 'SS', 
-  St: 'ST', 
-  Sv: 'SV', 
-  Sx: 'SX', 
-  Sy: 'SY', 
-  Sz: 'SZ', 
-  Tc: 'TC', 
-  Td: 'TD', 
-  Tf: 'TF', 
-  Tg: 'TG', 
-  Th: 'TH', 
-  Tj: 'TJ', 
-  Tk: 'TK', 
-  Tl: 'TL', 
-  Tm: 'TM', 
-  Tn: 'TN', 
-  To: 'TO', 
-  Tr: 'TR', 
-  Tt: 'TT', 
-  Tv: 'TV', 
-  Tw: 'TW', 
-  Tz: 'TZ', 
-  Ua: 'UA', 
-  Ug: 'UG', 
-  Um: 'UM', 
-  Us: 'US', 
-  Uy: 'UY', 
-  Uz: 'UZ', 
-  Va: 'VA', 
-  Vc: 'VC', 
-  Ve: 'VE', 
-  Vg: 'VG', 
-  Vi: 'VI', 
-  Vn: 'VN', 
-  Vu: 'VU', 
-  Wf: 'WF', 
-  Ws: 'WS', 
-  Xk: 'XK', 
-  Ye: 'YE', 
-  Yt: 'YT', 
-  Za: 'ZA', 
-  Zm: 'ZM', 
+  De: 'DE',
+  Ad: 'AD',
+  Ae: 'AE',
+  Af: 'AF',
+  Ag: 'AG',
+  Ai: 'AI',
+  Al: 'AL',
+  Am: 'AM',
+  Ao: 'AO',
+  Aq: 'AQ',
+  Ar: 'AR',
+  As: 'AS',
+  At: 'AT',
+  Au: 'AU',
+  Aw: 'AW',
+  Ax: 'AX',
+  Az: 'AZ',
+  Ba: 'BA',
+  Bb: 'BB',
+  Bd: 'BD',
+  Be: 'BE',
+  Bf: 'BF',
+  Bg: 'BG',
+  Bh: 'BH',
+  Bi: 'BI',
+  Bj: 'BJ',
+  Bl: 'BL',
+  Bm: 'BM',
+  Bn: 'BN',
+  Bo: 'BO',
+  Br: 'BR',
+  Bs: 'BS',
+  Bt: 'BT',
+  Bv: 'BV',
+  Bw: 'BW',
+  By: 'BY',
+  Bz: 'BZ',
+  Ca: 'CA',
+  Cc: 'CC',
+  Cd: 'CD',
+  Cf: 'CF',
+  Cg: 'CG',
+  Ch: 'CH',
+  Ci: 'CI',
+  Ck: 'CK',
+  Cl: 'CL',
+  Cm: 'CM',
+  Cn: 'CN',
+  Co: 'CO',
+  Cr: 'CR',
+  Cu: 'CU',
+  Cv: 'CV',
+  Cw: 'CW',
+  Cx: 'CX',
+  Cy: 'CY',
+  Cz: 'CZ',
+  Dj: 'DJ',
+  Dk: 'DK',
+  Dm: 'DM',
+  Do: 'DO',
+  Dz: 'DZ',
+  Ec: 'EC',
+  Ee: 'EE',
+  Eg: 'EG',
+  Eh: 'EH',
+  Er: 'ER',
+  Es: 'ES',
+  Et: 'ET',
+  Fi: 'FI',
+  Fj: 'FJ',
+  Fk: 'FK',
+  Fm: 'FM',
+  Fo: 'FO',
+  Fr: 'FR',
+  Ga: 'GA',
+  Gb: 'GB',
+  Gd: 'GD',
+  Ge: 'GE',
+  Gf: 'GF',
+  Gg: 'GG',
+  Gh: 'GH',
+  Gi: 'GI',
+  Gl: 'GL',
+  Gm: 'GM',
+  Gn: 'GN',
+  Gp: 'GP',
+  Gq: 'GQ',
+  Gr: 'GR',
+  Gs: 'GS',
+  Gt: 'GT',
+  Gu: 'GU',
+  Gw: 'GW',
+  Gy: 'GY',
+  Hk: 'HK',
+  Hm: 'HM',
+  Hn: 'HN',
+  Hr: 'HR',
+  Ht: 'HT',
+  Hu: 'HU',
+  Id: 'ID',
+  Ie: 'IE',
+  Il: 'IL',
+  Im: 'IM',
+  In: 'IN',
+  Io: 'IO',
+  Iq: 'IQ',
+  Ir: 'IR',
+  Is: 'IS',
+  It: 'IT',
+  Je: 'JE',
+  Jm: 'JM',
+  Jo: 'JO',
+  Jp: 'JP',
+  Ke: 'KE',
+  Kg: 'KG',
+  Kh: 'KH',
+  Ki: 'KI',
+  Km: 'KM',
+  Kn: 'KN',
+  Kp: 'KP',
+  Kr: 'KR',
+  Kw: 'KW',
+  Ky: 'KY',
+  Kz: 'KZ',
+  La: 'LA',
+  Lb: 'LB',
+  Lc: 'LC',
+  Li: 'LI',
+  Lk: 'LK',
+  Lr: 'LR',
+  Ls: 'LS',
+  Lt: 'LT',
+  Lu: 'LU',
+  Lv: 'LV',
+  Ly: 'LY',
+  Ma: 'MA',
+  Mc: 'MC',
+  Md: 'MD',
+  Me: 'ME',
+  Mf: 'MF',
+  Mg: 'MG',
+  Mh: 'MH',
+  Mk: 'MK',
+  Ml: 'ML',
+  Mm: 'MM',
+  Mn: 'MN',
+  Mo: 'MO',
+  Mp: 'MP',
+  Mq: 'MQ',
+  Mr: 'MR',
+  Ms: 'MS',
+  Mt: 'MT',
+  Mu: 'MU',
+  Mv: 'MV',
+  Mw: 'MW',
+  Mx: 'MX',
+  My: 'MY',
+  Mz: 'MZ',
+  Na: 'NA',
+  Nc: 'NC',
+  Ne: 'NE',
+  Nf: 'NF',
+  Ng: 'NG',
+  Ni: 'NI',
+  Nl: 'NL',
+  No: 'NO',
+  Np: 'NP',
+  Nr: 'NR',
+  Nu: 'NU',
+  Nz: 'NZ',
+  Om: 'OM',
+  Pa: 'PA',
+  Pe: 'PE',
+  Pf: 'PF',
+  Pg: 'PG',
+  Ph: 'PH',
+  Pk: 'PK',
+  Pl: 'PL',
+  Pm: 'PM',
+  Pn: 'PN',
+  Pr: 'PR',
+  Ps: 'PS',
+  Pt: 'PT',
+  Pw: 'PW',
+  Py: 'PY',
+  Qa: 'QA',
+  Re: 'RE',
+  Ro: 'RO',
+  Rs: 'RS',
+  Ru: 'RU',
+  Rw: 'RW',
+  Sa: 'SA',
+  Sb: 'SB',
+  Sc: 'SC',
+  Sd: 'SD',
+  Se: 'SE',
+  Sg: 'SG',
+  Si: 'SI',
+  Sj: 'SJ',
+  Sk: 'SK',
+  Sl: 'SL',
+  Sm: 'SM',
+  Sn: 'SN',
+  So: 'SO',
+  Sr: 'SR',
+  Ss: 'SS',
+  St: 'ST',
+  Sv: 'SV',
+  Sx: 'SX',
+  Sy: 'SY',
+  Sz: 'SZ',
+  Tc: 'TC',
+  Td: 'TD',
+  Tf: 'TF',
+  Tg: 'TG',
+  Th: 'TH',
+  Tj: 'TJ',
+  Tk: 'TK',
+  Tl: 'TL',
+  Tm: 'TM',
+  Tn: 'TN',
+  To: 'TO',
+  Tr: 'TR',
+  Tt: 'TT',
+  Tv: 'TV',
+  Tw: 'TW',
+  Tz: 'TZ',
+  Ua: 'UA',
+  Ug: 'UG',
+  Um: 'UM',
+  Us: 'US',
+  Uy: 'UY',
+  Uz: 'UZ',
+  Va: 'VA',
+  Vc: 'VC',
+  Ve: 'VE',
+  Vg: 'VG',
+  Vi: 'VI',
+  Vn: 'VN',
+  Vu: 'VU',
+  Wf: 'WF',
+  Ws: 'WS',
+  Xk: 'XK',
+  Ye: 'YE',
+  Yt: 'YT',
+  Za: 'ZA',
+  Zm: 'ZM',
   Zw: 'ZW'
 });
 
@@ -1003,11 +1051,11 @@ export type Notification = {|
 |};
 
 export const NotificationTypeValues = Object.freeze({
-  Transactions: 'TRANSACTIONS', 
-  Statements: 'STATEMENTS', 
-  ProductInfo: 'PRODUCT_INFO', 
-  Tax: 'TAX', 
-  ReceiptScanning: 'RECEIPT_SCANNING', 
+  Transactions: 'TRANSACTIONS',
+  Statements: 'STATEMENTS',
+  ProductInfo: 'PRODUCT_INFO',
+  Tax: 'TAX',
+  ReceiptScanning: 'RECEIPT_SCANNING',
   All: 'ALL'
 });
 
@@ -1030,12 +1078,12 @@ export type Overdraft = {|
 |};
 
 export const OverdraftApplicationStatusValues = Object.freeze({
-  Created: 'CREATED', 
-  InitialScoringPending: 'INITIAL_SCORING_PENDING', 
-  AccountSnapshotPending: 'ACCOUNT_SNAPSHOT_PENDING', 
-  AccountSnapshotVerificationPending: 'ACCOUNT_SNAPSHOT_VERIFICATION_PENDING', 
-  Offered: 'OFFERED', 
-  Rejected: 'REJECTED', 
+  Created: 'CREATED',
+  InitialScoringPending: 'INITIAL_SCORING_PENDING',
+  AccountSnapshotPending: 'ACCOUNT_SNAPSHOT_PENDING',
+  AccountSnapshotVerificationPending: 'ACCOUNT_SNAPSHOT_VERIFICATION_PENDING',
+  Offered: 'OFFERED',
+  Rejected: 'REJECTED',
   OverdraftCreated: 'OVERDRAFT_CREATED'
 });
 
@@ -1051,17 +1099,31 @@ export type PageInfo = {|
 |};
 
 export const PaymentFrequencyValues = Object.freeze({
-  Monthly: 'MONTHLY', 
-  Quarterly: 'QUARTERLY', 
-  Yearly: 'YEARLY', 
+  Monthly: 'MONTHLY',
+  Quarterly: 'QUARTERLY',
+  Yearly: 'YEARLY',
   None: 'NONE'
 });
 
 
 export type PaymentFrequency = $Values<typeof PaymentFrequencyValues>;
 
+export const PlatformValues = Object.freeze({
+  Ios: 'IOS',
+  Android: 'ANDROID',
+  Web: 'WEB'
+});
+
+
+export type Platform = $Values<typeof PlatformValues>;
+
+export type PublicMutationResult = {|
+  __typename?: 'PublicMutationResult',
+  success: $ElementType<Scalars, 'Boolean'>,
+|};
+
 export const PurchaseStateValues = Object.freeze({
-  Processed: 'PROCESSED', 
+  Processed: 'PROCESSED',
   Pending: 'PENDING'
 });
 
@@ -1069,10 +1131,10 @@ export const PurchaseStateValues = Object.freeze({
 export type PurchaseState = $Values<typeof PurchaseStateValues>;
 
 export const PurchaseTypeValues = Object.freeze({
-  BasicInitial: 'BASIC_INITIAL', 
-  Basic: 'BASIC', 
-  Premium: 'PREMIUM', 
-  Card: 'CARD', 
+  BasicInitial: 'BASIC_INITIAL',
+  Basic: 'BASIC',
+  Premium: 'PREMIUM',
+  Card: 'CARD',
   Lexoffice: 'LEXOFFICE'
 });
 
@@ -1090,21 +1152,21 @@ export type ReferralDetails = {|
   __typename?: 'ReferralDetails',
   code?: ?$ElementType<Scalars, 'String'>,
   link?: ?$ElementType<Scalars, 'String'>,
-  /** Amount in euros granted to user and his referee */
+  /** Amount in euros granted to user and their referee */
   bonusAmount: $ElementType<Scalars, 'Int'>,
 |};
 
 export const ScopeTypeValues = Object.freeze({
-  Offline: 'OFFLINE', 
-  Accounts: 'ACCOUNTS', 
-  Users: 'USERS', 
-  Transactions: 'TRANSACTIONS', 
-  Transfers: 'TRANSFERS', 
-  Subscriptions: 'SUBSCRIPTIONS', 
-  Statements: 'STATEMENTS', 
-  Admin: 'ADMIN', 
-  Clients: 'CLIENTS', 
-  Overdraft: 'OVERDRAFT', 
+  Offline: 'OFFLINE',
+  Accounts: 'ACCOUNTS',
+  Users: 'USERS',
+  Transactions: 'TRANSACTIONS',
+  Transfers: 'TRANSFERS',
+  Subscriptions: 'SUBSCRIPTIONS',
+  Statements: 'STATEMENTS',
+  Admin: 'ADMIN',
+  Clients: 'CLIENTS',
+  Overdraft: 'OVERDRAFT',
   Banners: 'BANNERS'
 });
 
@@ -1129,8 +1191,8 @@ export type SepaTransfer = {|
 |};
 
 export const SepaTransferStatusValues = Object.freeze({
-  Authorized: 'AUTHORIZED', 
-  Confirmed: 'CONFIRMED', 
+  Authorized: 'AUTHORIZED',
+  Confirmed: 'CONFIRMED',
   Booked: 'BOOKED'
 });
 
@@ -1138,9 +1200,9 @@ export const SepaTransferStatusValues = Object.freeze({
 export type SepaTransferStatus = $Values<typeof SepaTransferStatusValues>;
 
 export const StandingOrderReoccurrenceTypeValues = Object.freeze({
-  Monthly: 'MONTHLY', 
-  Quarterly: 'QUARTERLY', 
-  EverySixMonths: 'EVERY_SIX_MONTHS', 
+  Monthly: 'MONTHLY',
+  Quarterly: 'QUARTERLY',
+  EverySixMonths: 'EVERY_SIX_MONTHS',
   Annually: 'ANNUALLY'
 });
 
@@ -1240,6 +1302,7 @@ export type Transaction = {|
   category?: ?TransactionCategory,
   /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+  personalNote?: ?$ElementType<Scalars, 'String'>,
   purpose?: ?$ElementType<Scalars, 'String'>,
   documentNumber?: ?$ElementType<Scalars, 'String'>,
   documentPreviewUrl?: ?$ElementType<Scalars, 'String'>,
@@ -1250,16 +1313,16 @@ export type Transaction = {|
 |};
 
 export const TransactionCategoryValues = Object.freeze({
-  Private: 'PRIVATE', 
-  Vat: 'VAT', 
-  Vat_0: 'VAT_0', 
-  Vat_7: 'VAT_7', 
-  Vat_19: 'VAT_19', 
-  TaxPayment: 'TAX_PAYMENT', 
-  VatPayment: 'VAT_PAYMENT', 
-  TaxRefund: 'TAX_REFUND', 
-  VatRefund: 'VAT_REFUND', 
-  VatSaving: 'VAT_SAVING', 
+  Private: 'PRIVATE',
+  Vat: 'VAT',
+  Vat_0: 'VAT_0',
+  Vat_7: 'VAT_7',
+  Vat_19: 'VAT_19',
+  TaxPayment: 'TAX_PAYMENT',
+  VatPayment: 'VAT_PAYMENT',
+  TaxRefund: 'TAX_REFUND',
+  VatRefund: 'VAT_REFUND',
+  VatSaving: 'VAT_SAVING',
   TaxSaving: 'TAX_SAVING'
 });
 
@@ -1312,10 +1375,10 @@ export type TransactionFee = {|
 |};
 
 export const TransactionFeeStatusValues = Object.freeze({
-  Created: 'CREATED', 
-  Charged: 'CHARGED', 
-  Refunded: 'REFUNDED', 
-  Cancelled: 'CANCELLED', 
+  Created: 'CREATED',
+  Charged: 'CHARGED',
+  Refunded: 'REFUNDED',
+  Cancelled: 'CANCELLED',
   RefundInitiated: 'REFUND_INITIATED'
 });
 
@@ -1323,10 +1386,10 @@ export const TransactionFeeStatusValues = Object.freeze({
 export type TransactionFeeStatus = $Values<typeof TransactionFeeStatusValues>;
 
 export const TransactionFeeTypeValues = Object.freeze({
-  Atm: 'ATM', 
-  ForeignTransaction: 'FOREIGN_TRANSACTION', 
-  DirectDebitReturn: 'DIRECT_DEBIT_RETURN', 
-  SecondReminderEmail: 'SECOND_REMINDER_EMAIL', 
+  Atm: 'ATM',
+  ForeignTransaction: 'FOREIGN_TRANSACTION',
+  DirectDebitReturn: 'DIRECT_DEBIT_RETURN',
+  SecondReminderEmail: 'SECOND_REMINDER_EMAIL',
   CardReplacement: 'CARD_REPLACEMENT'
 });
 
@@ -1372,36 +1435,36 @@ export type TransactionFilter = {|
 |};
 
 export const TransactionProjectionTypeValues = Object.freeze({
-  CreditPresentment: 'CREDIT_PRESENTMENT', 
-  CashManual: 'CASH_MANUAL', 
-  Atm: 'ATM', 
-  CancelManualLoad: 'CANCEL_MANUAL_LOAD', 
-  CardUsage: 'CARD_USAGE', 
-  DirectDebitAutomaticTopup: 'DIRECT_DEBIT_AUTOMATIC_TOPUP', 
-  DirectDebitReturn: 'DIRECT_DEBIT_RETURN', 
-  DisputeClearing: 'DISPUTE_CLEARING', 
-  ManualLoad: 'MANUAL_LOAD', 
-  WireTransferTopup: 'WIRE_TRANSFER_TOPUP', 
-  TransferToBankAccount: 'TRANSFER_TO_BANK_ACCOUNT', 
-  CancellationBooking: 'CANCELLATION_BOOKING', 
-  CancellationDoubleBooking: 'CANCELLATION_DOUBLE_BOOKING', 
-  CreditTransferCancellation: 'CREDIT_TRANSFER_CANCELLATION', 
-  CurrencyTransactionCancellation: 'CURRENCY_TRANSACTION_CANCELLATION', 
-  DirectDebit: 'DIRECT_DEBIT', 
-  ForeignPayment: 'FOREIGN_PAYMENT', 
-  Other: 'OTHER', 
-  SepaCreditTransferReturn: 'SEPA_CREDIT_TRANSFER_RETURN', 
-  SepaCreditTransfer: 'SEPA_CREDIT_TRANSFER', 
-  SepaDirectDebitReturn: 'SEPA_DIRECT_DEBIT_RETURN', 
-  SepaDirectDebit: 'SEPA_DIRECT_DEBIT', 
-  Transfer: 'TRANSFER', 
-  InternationalCreditTransfer: 'INTERNATIONAL_CREDIT_TRANSFER', 
-  CancellationSepaDirectDebitReturn: 'CANCELLATION_SEPA_DIRECT_DEBIT_RETURN', 
-  Rebooking: 'REBOOKING', 
-  CancellationDirectDebit: 'CANCELLATION_DIRECT_DEBIT', 
-  CancellationSepaCreditTransferReturn: 'CANCELLATION_SEPA_CREDIT_TRANSFER_RETURN', 
-  CardTransaction: 'CARD_TRANSACTION', 
-  InterestAccrued: 'INTEREST_ACCRUED', 
+  CreditPresentment: 'CREDIT_PRESENTMENT',
+  CashManual: 'CASH_MANUAL',
+  Atm: 'ATM',
+  CancelManualLoad: 'CANCEL_MANUAL_LOAD',
+  CardUsage: 'CARD_USAGE',
+  DirectDebitAutomaticTopup: 'DIRECT_DEBIT_AUTOMATIC_TOPUP',
+  DirectDebitReturn: 'DIRECT_DEBIT_RETURN',
+  DisputeClearing: 'DISPUTE_CLEARING',
+  ManualLoad: 'MANUAL_LOAD',
+  WireTransferTopup: 'WIRE_TRANSFER_TOPUP',
+  TransferToBankAccount: 'TRANSFER_TO_BANK_ACCOUNT',
+  CancellationBooking: 'CANCELLATION_BOOKING',
+  CancellationDoubleBooking: 'CANCELLATION_DOUBLE_BOOKING',
+  CreditTransferCancellation: 'CREDIT_TRANSFER_CANCELLATION',
+  CurrencyTransactionCancellation: 'CURRENCY_TRANSACTION_CANCELLATION',
+  DirectDebit: 'DIRECT_DEBIT',
+  ForeignPayment: 'FOREIGN_PAYMENT',
+  Other: 'OTHER',
+  SepaCreditTransferReturn: 'SEPA_CREDIT_TRANSFER_RETURN',
+  SepaCreditTransfer: 'SEPA_CREDIT_TRANSFER',
+  SepaDirectDebitReturn: 'SEPA_DIRECT_DEBIT_RETURN',
+  SepaDirectDebit: 'SEPA_DIRECT_DEBIT',
+  Transfer: 'TRANSFER',
+  InternationalCreditTransfer: 'INTERNATIONAL_CREDIT_TRANSFER',
+  CancellationSepaDirectDebitReturn: 'CANCELLATION_SEPA_DIRECT_DEBIT_RETURN',
+  Rebooking: 'REBOOKING',
+  CancellationDirectDebit: 'CANCELLATION_DIRECT_DEBIT',
+  CancellationSepaCreditTransferReturn: 'CANCELLATION_SEPA_CREDIT_TRANSFER_RETURN',
+  CardTransaction: 'CARD_TRANSACTION',
+  InterestAccrued: 'INTEREST_ACCRUED',
   CancellationInterestAccrued: 'CANCELLATION_INTEREST_ACCRUED'
 });
 
@@ -1445,6 +1508,8 @@ export type Transfer = {|
   lastExecutionDate?: ?$ElementType<Scalars, 'DateTime'>,
   /** The purpose of the transfer - 140 max characters */
   purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The personal note of the transfer - 140 max characters */
+  personalNote?: ?$ElementType<Scalars, 'String'>,
   /** The end to end ID of the transfer */
   e2eId?: ?$ElementType<Scalars, 'String'>,
   /** The reoccurrence type of the payments for Standing Orders */
@@ -1474,17 +1539,17 @@ export type TransfersConnectionFilter = {|
 |};
 
 export const TransferStatusValues = Object.freeze({
-  Authorized: 'AUTHORIZED', 
-  Confirmed: 'CONFIRMED', 
-  Booked: 'BOOKED', 
-  Created: 'CREATED', 
-  Active: 'ACTIVE', 
-  Inactive: 'INACTIVE', 
-  Canceled: 'CANCELED', 
-  AuthorizationRequired: 'AUTHORIZATION_REQUIRED', 
-  ConfirmationRequired: 'CONFIRMATION_REQUIRED', 
-  Scheduled: 'SCHEDULED', 
-  Executed: 'EXECUTED', 
+  Authorized: 'AUTHORIZED',
+  Confirmed: 'CONFIRMED',
+  Booked: 'BOOKED',
+  Created: 'CREATED',
+  Active: 'ACTIVE',
+  Inactive: 'INACTIVE',
+  Canceled: 'CANCELED',
+  AuthorizationRequired: 'AUTHORIZATION_REQUIRED',
+  ConfirmationRequired: 'CONFIRMATION_REQUIRED',
+  Scheduled: 'SCHEDULED',
+  Executed: 'EXECUTED',
   Failed: 'FAILED'
 });
 
@@ -1498,8 +1563,8 @@ export type TransferSuggestion = {|
 |};
 
 export const TransferTypeValues = Object.freeze({
-  SepaTransfer: 'SEPA_TRANSFER', 
-  StandingOrder: 'STANDING_ORDER', 
+  SepaTransfer: 'SEPA_TRANSFER',
+  StandingOrder: 'STANDING_ORDER',
   TimedOrder: 'TIMED_ORDER'
 });
 
@@ -1550,6 +1615,8 @@ export type UpdateTransferInput = {|
   lastExecutionDate?: ?$ElementType<Scalars, 'DateTime'>,
   /** The purpose of the Standing Order - 140 max characters, if not specified with the update, it will be set to null */
   purpose?: ?$ElementType<Scalars, 'String'>,
+  /** The personal note of the transfer - 140 max characters */
+  personalNote?: ?$ElementType<Scalars, 'String'>,
   /** The end to end ID of the Standing Order, if not specified with the update, it will be set to null */
   e2eId?: ?$ElementType<Scalars, 'String'>,
   /** The reoccurrence type of the payments for Standing Orders */
@@ -1641,7 +1708,7 @@ export type UserAvailablePlansArgs = {|
 
 
 export type UserMetadataArgs = {|
-  os?: ?UserOs,
+  platform?: ?Platform,
 |};
 
 export type UserIntegration = {|
@@ -1669,14 +1736,6 @@ export type UserMetadata = {|
   signupCompleted: $ElementType<Scalars, 'Boolean'>,
 |};
 
-export const UserOsValues = Object.freeze({
-  Ios: 'IOS', 
-  Android: 'ANDROID'
-});
-
-
-export type UserOs = $Values<typeof UserOsValues>;
-
 export type UserSubscription = {|
   __typename?: 'UserSubscription',
   /** The type of the plans a user has subscribed to */
@@ -1699,6 +1758,45 @@ export type UserTaxDetails = {|
   needsToProvideTaxIdentification: $ElementType<Scalars, 'Boolean'>,
 |};
 
+export type UserUpdateInput = {|
+  birthDate?: ?$ElementType<Scalars, 'DateTime'>,
+  city?: ?$ElementType<Scalars, 'String'>,
+  firstName?: ?$ElementType<Scalars, 'String'>,
+  lastName?: ?$ElementType<Scalars, 'String'>,
+  country?: ?Nationality,
+  nationality?: ?Nationality,
+  postCode?: ?$ElementType<Scalars, 'String'>,
+  street?: ?$ElementType<Scalars, 'String'>,
+  birthPlace?: ?$ElementType<Scalars, 'String'>,
+  /** Sets a mobile number for the user to be verified later */
+  untrustedPhoneNumber?: ?$ElementType<Scalars, 'String'>,
+  vatPaymentFrequency?: ?PaymentFrequency,
+  vatNumber?: ?$ElementType<Scalars, 'String'>,
+  vatRate?: ?$ElementType<Scalars, 'Int'>,
+  language?: ?$ElementType<Scalars, 'String'>,
+  /** Indicates whether the user pays taxes in the US */
+  isUSPerson?: ?$ElementType<Scalars, 'Boolean'>,
+  /** The version of terms user has accepted */
+  acceptedTermsVersion?: ?$ElementType<Scalars, 'String'>,
+  businessPurpose?: ?$ElementType<Scalars, 'String'>,
+  economicSector?: ?$ElementType<Scalars, 'String'>,
+  otherEconomicSector?: ?$ElementType<Scalars, 'String'>,
+  businessTradingName?: ?$ElementType<Scalars, 'String'>,
+  adjustAdvancePayments?: ?$ElementType<Scalars, 'Boolean'>,
+  companyType?: ?CompanyType,
+  /** Indicates user has accepted Kontist direct debit mandate */
+  directDebitMandateAccepted?: ?$ElementType<Scalars, 'Boolean'>,
+  /** Indicates user has confirmed he is opening their account in their name, for the use of their business */
+  ownEconomicInterestConfirmed?: ?$ElementType<Scalars, 'Boolean'>,
+  /** Indicates user has confirmed he is acting as a business and not a consumer */
+  nonConsumerConfirmed?: ?$ElementType<Scalars, 'Boolean'>,
+  /** Indicates user has accepted to receive Kontist marketing communication */
+  marketingConsentAccepted?: ?$ElementType<Scalars, 'Boolean'>,
+  /** Indicates user has accepted Wirecard direct debit mandate */
+  wirecardDirectDebitMandateAccepted?: ?$ElementType<Scalars, 'Boolean'>,
+  wirecardCardType?: ?$ElementType<Scalars, 'String'>,
+|};
+
 export type WhitelistCardResponse = {|
   __typename?: 'WhitelistCardResponse',
   id: $ElementType<Scalars, 'String'>,
@@ -1707,8 +1805,8 @@ export type WhitelistCardResponse = {|
 |};
 
 export const WirecardCardStatusValues = Object.freeze({
-  NotOrdered: 'NOT_ORDERED', 
-  Ordered: 'ORDERED', 
+  NotOrdered: 'NOT_ORDERED',
+  Ordered: 'ORDERED',
   Issued: 'ISSUED'
 });
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -117,12 +117,6 @@ export type AccountStats = {
   taxMissing: Scalars['Int'];
 };
 
-export type AttributionData = {
-  /** Platform used for signup */
-  platform?: Maybe<Platform>;
-  trackingId?: Maybe<Scalars['String']>;
-};
-
 export type AvailableStatements = {
   __typename?: 'AvailableStatements';
   year: Scalars['Int'];
@@ -359,15 +353,6 @@ export type CreateTransferInput = {
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
 };
 
-export type CreateUserInput = {
-  /** User's email. This will be used as their username. */
-  email: Scalars['String'];
-  password: Scalars['String'];
-  language?: Maybe<Scalars['String']>;
-  attribution?: Maybe<AttributionData>;
-  marketingConsentAccepted?: Maybe<Scalars['Boolean']>;
-};
-
 export type DirectDebitFee = {
   __typename?: 'DirectDebitFee';
   id: Scalars['Int'];
@@ -523,12 +508,6 @@ export type Mutation = {
   /** Update user's subscription plan */
   updateSubscriptionPlan: UpdateSubscriptionPlanResult;
   dismissBanner: MutationResult;
-  /** Connect user to a bookkeeping partner */
-  connectIntegration: MutationResult;
-  /** Update user signup information */
-  updateUserSignupInformation: MutationResult;
-  /** Create a new user */
-  createUser: PublicMutationResult;
   /** Update the push-notifications a user should receive */
   updateUserNotifications: Array<Notification>;
 };
@@ -725,22 +704,6 @@ export type MutationUpdateSubscriptionPlanArgs = {
 
 export type MutationDismissBannerArgs = {
   name: BannerName;
-};
-
-
-export type MutationConnectIntegrationArgs = {
-  type: IntegrationType;
-  authorizationData: Scalars['String'];
-};
-
-
-export type MutationUpdateUserSignupInformationArgs = {
-  payload: UserUpdateInput;
-};
-
-
-export type MutationCreateUserArgs = {
-  payload: CreateUserInput;
 };
 
 
@@ -1060,17 +1023,6 @@ export enum PaymentFrequency {
   None = 'NONE'
 }
 
-export enum Platform {
-  Ios = 'IOS',
-  Android = 'ANDROID',
-  Web = 'WEB'
-}
-
-export type PublicMutationResult = {
-  __typename?: 'PublicMutationResult';
-  success: Scalars['Boolean'];
-};
-
 export enum PurchaseState {
   Processed = 'PROCESSED',
   Pending = 'PENDING'
@@ -1095,7 +1047,7 @@ export type ReferralDetails = {
   __typename?: 'ReferralDetails';
   code?: Maybe<Scalars['String']>;
   link?: Maybe<Scalars['String']>;
-  /** Amount in euros granted to user and their referee */
+  /** Amount in euros granted to user and his referee */
   bonusAmount: Scalars['Int'];
 };
 
@@ -1634,7 +1586,7 @@ export type UserAvailablePlansArgs = {
 
 
 export type UserMetadataArgs = {
-  platform?: Maybe<Platform>;
+  os?: Maybe<UserOs>;
 };
 
 export type UserIntegration = {
@@ -1662,6 +1614,11 @@ export type UserMetadata = {
   signupCompleted: Scalars['Boolean'];
 };
 
+export enum UserOs {
+  Ios = 'IOS',
+  Android = 'ANDROID'
+}
+
 export type UserSubscription = {
   __typename?: 'UserSubscription';
   /** The type of the plans a user has subscribed to */
@@ -1676,52 +1633,13 @@ export type UserTaxDetails = {
   lastTaxPaymentDate?: Maybe<Scalars['DateTime']>;
   lastVatPaymentDate?: Maybe<Scalars['DateTime']>;
   vatPaymentFrequency?: Maybe<PaymentFrequency>;
-  /** @deprecated This field will be removed in an upcoming release. Do not rely on it for any new features */
+  /** @deprecated This field will be removed in an upcoming release, do not rely on it for any new code */
   taxPaymentFrequency?: Maybe<TaxPaymentFrequency>;
   taxRate?: Maybe<Scalars['Int']>;
   vatRate?: Maybe<Scalars['Int']>;
   taxNumber?: Maybe<Scalars['String']>;
   vatNumber?: Maybe<Scalars['String']>;
   needsToProvideTaxIdentification: Scalars['Boolean'];
-};
-
-export type UserUpdateInput = {
-  birthDate?: Maybe<Scalars['DateTime']>;
-  city?: Maybe<Scalars['String']>;
-  firstName?: Maybe<Scalars['String']>;
-  lastName?: Maybe<Scalars['String']>;
-  country?: Maybe<Nationality>;
-  nationality?: Maybe<Nationality>;
-  postCode?: Maybe<Scalars['String']>;
-  street?: Maybe<Scalars['String']>;
-  birthPlace?: Maybe<Scalars['String']>;
-  /** Sets a mobile number for the user to be verified later */
-  untrustedPhoneNumber?: Maybe<Scalars['String']>;
-  vatPaymentFrequency?: Maybe<PaymentFrequency>;
-  vatNumber?: Maybe<Scalars['String']>;
-  vatRate?: Maybe<Scalars['Int']>;
-  language?: Maybe<Scalars['String']>;
-  /** Indicates whether the user pays taxes in the US */
-  isUSPerson?: Maybe<Scalars['Boolean']>;
-  /** The version of terms user has accepted */
-  acceptedTermsVersion?: Maybe<Scalars['String']>;
-  businessPurpose?: Maybe<Scalars['String']>;
-  economicSector?: Maybe<Scalars['String']>;
-  otherEconomicSector?: Maybe<Scalars['String']>;
-  businessTradingName?: Maybe<Scalars['String']>;
-  adjustAdvancePayments?: Maybe<Scalars['Boolean']>;
-  companyType?: Maybe<CompanyType>;
-  /** Indicates user has accepted Kontist direct debit mandate */
-  directDebitMandateAccepted?: Maybe<Scalars['Boolean']>;
-  /** Indicates user has confirmed he is opening their account in their name, for the use of their business */
-  ownEconomicInterestConfirmed?: Maybe<Scalars['Boolean']>;
-  /** Indicates user has confirmed he is acting as a business and not a consumer */
-  nonConsumerConfirmed?: Maybe<Scalars['Boolean']>;
-  /** Indicates user has accepted to receive Kontist marketing communication */
-  marketingConsentAccepted?: Maybe<Scalars['Boolean']>;
-  /** Indicates user has accepted Wirecard direct debit mandate */
-  wirecardDirectDebitMandateAccepted?: Maybe<Scalars['Boolean']>;
-  wirecardCardType?: Maybe<Scalars['String']>;
 };
 
 export type WhitelistCardResponse = {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -495,7 +495,11 @@ export type Mutation = {
   reorderCard: Card;
   /** Set the card holder representation for the customer */
   setCardHolderRepresentation: Scalars['String'];
-  /** Categorize a transaction with an optional custom booking date for VAT or Tax categories */
+  /**
+   * Categorize a transaction with an optional custom booking date for VAT or Tax categories
+   * @deprecated This method will be removed in an upcoming release,
+   *             we should now use 'updateTransaction' method instead.
+   */
   categorizeTransaction: Transaction;
   /** Update a transaction with a category (with an optional custom booking date for VAT or Tax categories) and/or a personal note */
   updateTransaction: Transaction;
@@ -667,7 +671,10 @@ export type MutationSetCardHolderRepresentationArgs = {
   cardHolderRepresentation: Scalars['String'];
 };
 
-
+/**
+ * @deprecated This mutation will be removed in an upcoming release,
+ *             we should now use 'MutationUpdateTransactionArgs' instead.
+ */
 export type MutationCategorizeTransactionArgs = {
   id: Scalars['String'];
   category?: Maybe<TransactionCategory>;

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -117,6 +117,12 @@ export type AccountStats = {
   taxMissing: Scalars['Int'];
 };
 
+export type AttributionData = {
+  /** Platform used for signup */
+  platform?: Maybe<Platform>;
+  trackingId?: Maybe<Scalars['String']>;
+};
+
 export type AvailableStatements = {
   __typename?: 'AvailableStatements';
   year: Scalars['Int'];
@@ -315,6 +321,8 @@ export type CreateSepaTransferInput = {
   amount: Scalars['Int'];
   /** The purpose of the SEPA Transfer - 140 max characters */
   purpose?: Maybe<Scalars['String']>;
+  /** The personal note of the SEPA Transfer - 140 max characters */
+  personalNote?: Maybe<Scalars['String']>;
   /** The end to end ID of the SEPA Transfer */
   e2eId?: Maybe<Scalars['String']>;
 };
@@ -339,6 +347,8 @@ export type CreateTransferInput = {
   lastExecutionDate?: Maybe<Scalars['DateTime']>;
   /** The purpose of the transfer - 140 max characters */
   purpose?: Maybe<Scalars['String']>;
+  /** The personal note of the transfer - 140 max characters */
+  personalNote?: Maybe<Scalars['String']>;
   /** The end to end ID of the transfer */
   e2eId?: Maybe<Scalars['String']>;
   /** The reoccurrence type of the payments for Standing Orders */
@@ -349,6 +359,14 @@ export type CreateTransferInput = {
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
 };
 
+export type CreateUserInput = {
+  /** User's email. This will be used as their username. */
+  email: Scalars['String'];
+  password: Scalars['String'];
+  language?: Maybe<Scalars['String']>;
+  attribution?: Maybe<AttributionData>;
+  marketingConsentAccepted?: Maybe<Scalars['Boolean']>;
+};
 
 export type DirectDebitFee = {
   __typename?: 'DirectDebitFee';
@@ -479,6 +497,8 @@ export type Mutation = {
   setCardHolderRepresentation: Scalars['String'];
   /** Categorize a transaction with an optional custom booking date for VAT or Tax categories */
   categorizeTransaction: Transaction;
+  /** Update a transaction with a category (with an optional custom booking date for VAT or Tax categories) and/or a personal note */
+  updateTransaction: Transaction;
   /** Create Overdraft Application  - only available for Kontist Application */
   requestOverdraft?: Maybe<Overdraft>;
   /** Activate Overdraft Application  - only available for Kontist Application */
@@ -499,6 +519,12 @@ export type Mutation = {
   /** Update user's subscription plan */
   updateSubscriptionPlan: UpdateSubscriptionPlanResult;
   dismissBanner: MutationResult;
+  /** Connect user to a bookkeeping partner */
+  connectIntegration: MutationResult;
+  /** Update user signup information */
+  updateUserSignupInformation: MutationResult;
+  /** Create a new user */
+  createUser: PublicMutationResult;
   /** Update the push-notifications a user should receive */
   updateUserNotifications: Array<Notification>;
 };
@@ -648,6 +674,13 @@ export type MutationCategorizeTransactionArgs = {
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
 };
 
+export type MutationUpdateTransactionArgs = {
+  id: Scalars['String'];
+  category?: Maybe<TransactionCategory>;
+  userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
+  personalNote?: Maybe<Scalars['String']>;
+};
+
 
 export type MutationUpdateOverdraftArgs = {
   offeredScreenShown?: Maybe<Scalars['Boolean']>;
@@ -685,6 +718,22 @@ export type MutationUpdateSubscriptionPlanArgs = {
 
 export type MutationDismissBannerArgs = {
   name: BannerName;
+};
+
+
+export type MutationConnectIntegrationArgs = {
+  type: IntegrationType;
+  authorizationData: Scalars['String'];
+};
+
+
+export type MutationUpdateUserSignupInformationArgs = {
+  payload: UserUpdateInput;
+};
+
+
+export type MutationCreateUserArgs = {
+  payload: CreateUserInput;
 };
 
 
@@ -1004,6 +1053,17 @@ export enum PaymentFrequency {
   None = 'NONE'
 }
 
+export enum Platform {
+  Ios = 'IOS',
+  Android = 'ANDROID',
+  Web = 'WEB'
+}
+
+export type PublicMutationResult = {
+  __typename?: 'PublicMutationResult';
+  success: Scalars['Boolean'];
+};
+
 export enum PurchaseState {
   Processed = 'PROCESSED',
   Pending = 'PENDING'
@@ -1028,7 +1088,7 @@ export type ReferralDetails = {
   __typename?: 'ReferralDetails';
   code?: Maybe<Scalars['String']>;
   link?: Maybe<Scalars['String']>;
-  /** Amount in euros granted to user and his referee */
+  /** Amount in euros granted to user and their referee */
   bonusAmount: Scalars['Int'];
 };
 
@@ -1163,6 +1223,7 @@ export type Transaction = {
   category?: Maybe<TransactionCategory>;
   /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
+  personalNote?: Maybe<Scalars['String']>;
   purpose?: Maybe<Scalars['String']>;
   documentNumber?: Maybe<Scalars['String']>;
   documentPreviewUrl?: Maybe<Scalars['String']>;
@@ -1356,6 +1417,8 @@ export type Transfer = {
   lastExecutionDate?: Maybe<Scalars['DateTime']>;
   /** The purpose of the transfer - 140 max characters */
   purpose?: Maybe<Scalars['String']>;
+  /** The personal note of the transfer - 140 max characters */
+  personalNote?: Maybe<Scalars['String']>;
   /** The end to end ID of the transfer */
   e2eId?: Maybe<Scalars['String']>;
   /** The reoccurrence type of the payments for Standing Orders */
@@ -1455,6 +1518,8 @@ export type UpdateTransferInput = {
   lastExecutionDate?: Maybe<Scalars['DateTime']>;
   /** The purpose of the Standing Order - 140 max characters, if not specified with the update, it will be set to null */
   purpose?: Maybe<Scalars['String']>;
+  /** The personal note of the transfer - 140 max characters */
+  personalNote?: Maybe<Scalars['String']>;
   /** The end to end ID of the Standing Order, if not specified with the update, it will be set to null */
   e2eId?: Maybe<Scalars['String']>;
   /** The reoccurrence type of the payments for Standing Orders */
@@ -1562,7 +1627,7 @@ export type UserAvailablePlansArgs = {
 
 
 export type UserMetadataArgs = {
-  os?: Maybe<UserOs>;
+  platform?: Maybe<Platform>;
 };
 
 export type UserIntegration = {
@@ -1590,11 +1655,6 @@ export type UserMetadata = {
   signupCompleted: Scalars['Boolean'];
 };
 
-export enum UserOs {
-  Ios = 'IOS',
-  Android = 'ANDROID'
-}
-
 export type UserSubscription = {
   __typename?: 'UserSubscription';
   /** The type of the plans a user has subscribed to */
@@ -1609,13 +1669,52 @@ export type UserTaxDetails = {
   lastTaxPaymentDate?: Maybe<Scalars['DateTime']>;
   lastVatPaymentDate?: Maybe<Scalars['DateTime']>;
   vatPaymentFrequency?: Maybe<PaymentFrequency>;
-  /** @deprecated This field will be removed in an upcoming release, do not rely on it for any new code */
+  /** @deprecated This field will be removed in an upcoming release. Do not rely on it for any new features */
   taxPaymentFrequency?: Maybe<TaxPaymentFrequency>;
   taxRate?: Maybe<Scalars['Int']>;
   vatRate?: Maybe<Scalars['Int']>;
   taxNumber?: Maybe<Scalars['String']>;
   vatNumber?: Maybe<Scalars['String']>;
   needsToProvideTaxIdentification: Scalars['Boolean'];
+};
+
+export type UserUpdateInput = {
+  birthDate?: Maybe<Scalars['DateTime']>;
+  city?: Maybe<Scalars['String']>;
+  firstName?: Maybe<Scalars['String']>;
+  lastName?: Maybe<Scalars['String']>;
+  country?: Maybe<Nationality>;
+  nationality?: Maybe<Nationality>;
+  postCode?: Maybe<Scalars['String']>;
+  street?: Maybe<Scalars['String']>;
+  birthPlace?: Maybe<Scalars['String']>;
+  /** Sets a mobile number for the user to be verified later */
+  untrustedPhoneNumber?: Maybe<Scalars['String']>;
+  vatPaymentFrequency?: Maybe<PaymentFrequency>;
+  vatNumber?: Maybe<Scalars['String']>;
+  vatRate?: Maybe<Scalars['Int']>;
+  language?: Maybe<Scalars['String']>;
+  /** Indicates whether the user pays taxes in the US */
+  isUSPerson?: Maybe<Scalars['Boolean']>;
+  /** The version of terms user has accepted */
+  acceptedTermsVersion?: Maybe<Scalars['String']>;
+  businessPurpose?: Maybe<Scalars['String']>;
+  economicSector?: Maybe<Scalars['String']>;
+  otherEconomicSector?: Maybe<Scalars['String']>;
+  businessTradingName?: Maybe<Scalars['String']>;
+  adjustAdvancePayments?: Maybe<Scalars['Boolean']>;
+  companyType?: Maybe<CompanyType>;
+  /** Indicates user has accepted Kontist direct debit mandate */
+  directDebitMandateAccepted?: Maybe<Scalars['Boolean']>;
+  /** Indicates user has confirmed he is opening their account in their name, for the use of their business */
+  ownEconomicInterestConfirmed?: Maybe<Scalars['Boolean']>;
+  /** Indicates user has confirmed he is acting as a business and not a consumer */
+  nonConsumerConfirmed?: Maybe<Scalars['Boolean']>;
+  /** Indicates user has accepted to receive Kontist marketing communication */
+  marketingConsentAccepted?: Maybe<Scalars['Boolean']>;
+  /** Indicates user has accepted Wirecard direct debit mandate */
+  wirecardDirectDebitMandateAccepted?: Maybe<Scalars['Boolean']>;
+  wirecardCardType?: Maybe<Scalars['String']>;
 };
 
 export type WhitelistCardResponse = {

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -228,7 +228,7 @@ export class Transaction extends IterableModel<TransactionModel> {
    * @param args   query parameters including category, userSelectedBookingDate and personalNote
    * @returns      the transaction with updated categorization data and updated personalNote
    */
-  public async updateMeta(args: MutationUpdateTransactionArgs) {
+  public async update(args: MutationUpdateTransactionArgs) {
     const result = await this.client.rawQuery(UPDATE_TRANSACTION, args);
     return result.updateTransaction;
   }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -4,6 +4,7 @@ import {
   AccountTransactionsArgs,
   BaseOperator,
   MutationCategorizeTransactionArgs,
+  MutationUpdateTransactionArgs,
   MutationCreateTransactionSplitsArgs,
   MutationDeleteTransactionSplitsArgs,
   MutationUpdateTransactionSplitsArgs,
@@ -51,6 +52,7 @@ const TRANSACTION_FIELDS = `
   paymentMethod
   category
   userSelectedBookingDate
+  personalNote
   purpose
   documentNumber
   documentPreviewUrl
@@ -101,6 +103,22 @@ export const CATEGORIZE_TRANSACTION = `mutation categorizeTransaction(
     id: $id
     category: $category
     userSelectedBookingDate: $userSelectedBookingDate
+  ) {
+    ${TRANSACTION_FIELDS}
+  }
+}`;
+
+export const UPDATE_TRANSACTION = `mutation updateTransaction(
+  $id: String!
+  $category: TransactionCategory,
+  $userSelectedBookingDate: DateTime,
+  $personalNote: String,
+) {
+  updateTransaction(
+    id: $id
+    category: $category
+    userSelectedBookingDate: $userSelectedBookingDate
+    personalNote: $personalNote
   ) {
     ${TRANSACTION_FIELDS}
   }
@@ -202,6 +220,17 @@ export class Transaction extends IterableModel<TransactionModel> {
   public async categorize(args: MutationCategorizeTransactionArgs) {
     const result = await this.client.rawQuery(CATEGORIZE_TRANSACTION, args);
     return result.categorizeTransaction;
+  }
+
+  /**
+   * Updates a transaction
+   *
+   * @param args   query parameters including category, userSelectedBookingDate and personalNote
+   * @returns      the transaction with updated categorization data and updated personalNote
+   */
+  public async updateMeta(args: MutationUpdateTransactionArgs) {
+    const result = await this.client.rawQuery(UPDATE_TRANSACTION, args);
+    return result.updateTransaction;
   }
 
   /**

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -213,6 +213,8 @@ export class Transaction extends IterableModel<TransactionModel> {
 
   /**
    * Categorizes a transaction
+   * @deprecated   This method will be removed in an upcoming release.
+   *               Use `transaction.update` method instead.
    *
    * @param args   query parameters including category and userSelectedBookingDate
    * @returns      the transaction with updated categorization data

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -27,6 +27,7 @@ const TRANSFER_FIELDS = `
   nextOccurrence
   category
   userSelectedBookingDate
+  personalNote
 `;
 
 const CREATE_TRANSFER = `mutation createTransfer($transfer: CreateTransferInput!) {

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -198,7 +198,7 @@ describe("Transaction", () => {
       } as any);
 
       // act
-      const result = await client.models.transaction.updateMeta({
+      const result = await client.models.transaction.update({
         id: transactionData.id,
         category: TransactionCategory.VatPayment,
         userSelectedBookingDate: new Date().toISOString(),

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -173,6 +173,42 @@ describe("Transaction", () => {
     });
   });
 
+  describe("#categorize", () => {
+    let client: Client;
+    let stub: any;
+
+    before(() => {
+      client = createClient();
+      stub = sinon.stub(client.graphQL, "rawQuery");
+    });
+
+    after(() => {
+      stub.restore();
+    });
+
+    it("should call rawQuery and return updated transaction details", async () => {
+      // arrange
+      const transactionData = createTransaction({
+        category: TransactionCategory.VatPayment,
+        userSelectedBookingDate: new Date().toISOString(),
+      });
+      stub.resolves({
+        categorizeTransaction: transactionData,
+      } as any);
+
+      // act
+      const result = await client.models.transaction.categorize({
+        id: transactionData.id,
+        category: TransactionCategory.VatPayment,
+        userSelectedBookingDate: new Date().toISOString(),
+      });
+
+      // assert
+      expect(stub.callCount).to.eq(1);
+      expect(result).to.deep.eq(transactionData);
+    });
+  });
+
   describe("#update", () => {
     let client: Client;
     let stub: any;

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -173,7 +173,7 @@ describe("Transaction", () => {
     });
   });
 
-  describe("#categorize", () => {
+  describe("#update", () => {
     let client: Client;
     let stub: any;
 
@@ -191,16 +191,18 @@ describe("Transaction", () => {
       const transactionData = createTransaction({
         category: TransactionCategory.VatPayment,
         userSelectedBookingDate: new Date().toISOString(),
+        personalNote: "Business lunch"
       });
       stub.resolves({
-        categorizeTransaction: transactionData,
+        updateTransaction: transactionData,
       } as any);
 
       // act
-      const result = await client.models.transaction.categorize({
+      const result = await client.models.transaction.updateMeta({
         id: transactionData.id,
         category: TransactionCategory.VatPayment,
         userSelectedBookingDate: new Date().toISOString(),
+        personalNote: transactionData.personalNote
       });
 
       // assert

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -261,11 +261,13 @@ describe("Transfer", () => {
   describe("update - SEPA Transfer", () => {
     const category = TransactionCategory.TaxPayment;
     const userSelectedBookingDate = new Date().toISOString();
+    const personalNote = "business travel"
     const updatePayload = {
       id: "some-id",
       type: TransferType.SepaTransfer,
       category,
-      userSelectedBookingDate
+      userSelectedBookingDate,
+      personalNote,
     };
 
     before(async () => {
@@ -273,7 +275,8 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         updateTransfer: {
           category,
-          userSelectedBookingDate
+          userSelectedBookingDate,
+          personalNote,
         }
       });
       result = await transferInstance.update(updatePayload);
@@ -289,7 +292,8 @@ describe("Transfer", () => {
     it("should return updateTransfer result", () => {
       expect(result).to.eql({
         category,
-        userSelectedBookingDate
+        userSelectedBookingDate,
+        personalNote
       });
     });
   });
@@ -297,11 +301,13 @@ describe("Transfer", () => {
   describe("update - Timed Order", () => {
     const category = TransactionCategory.TaxPayment;
     const userSelectedBookingDate = new Date().toISOString();
+    const personalNote = "best French restaurant in Berlin"
     const updatePayload = {
       id: "some-id",
       type: TransferType.TimedOrder,
       category,
-      userSelectedBookingDate
+      userSelectedBookingDate,
+      personalNote,
     };
 
     before(async () => {
@@ -309,7 +315,8 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         updateTransfer: {
           category,
-          userSelectedBookingDate
+          userSelectedBookingDate,
+          personalNote
         }
       });
       result = await transferInstance.update(updatePayload);
@@ -325,7 +332,8 @@ describe("Transfer", () => {
     it("should return updateTransfer result", () => {
       expect(result).to.eql({
         category,
-        userSelectedBookingDate
+        userSelectedBookingDate,
+        personalNote
       });
     });
   });


### PR DESCRIPTION
[Ticket 4831](https://app.zenhub.com/workspaces/kontist-engineering-5be06ab44b5806bc2bf14eca/issues/kontist/figure-app/4831) from the Transaction note epic. 

Update the schema with the `personalNote` field and the `updateTransaction` method. 
Deprecate the `categorizeTransaction` method which is now included in the `updateTransaction` method. 
Extend `transfer` and `transaction` tests.