### PR TITLE
Expose predicted* meta fields in categorizeTransaction response

### DIFF
--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1293,6 +1293,9 @@ export type Transaction = {|
   category?: ?TransactionCategory,
   /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+  predictedCategory?: ?TransactionCategory,
+  /** Date predicted for tax/vat payment/refund predicted category */
+  predictedUserSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
   purpose?: ?$ElementType<Scalars, 'String'>,
   documentNumber?: ?$ElementType<Scalars, 'String'>,
   documentPreviewUrl?: ?$ElementType<Scalars, 'String'>,
@@ -1508,6 +1511,10 @@ export type Transfer = {|
   category?: ?TransactionCategory,
   /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
+  /** Predicted category for the SEPA Transfer */
+  predictedCategory?: ?TransactionCategory,
+  /** Date predicted for tax/vat payment/refund predicted category */
+  predictedUserSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
 |};
 
 export type TransfersConnection = {|

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1213,6 +1213,9 @@ export type Transaction = {
   category?: Maybe<TransactionCategory>;
   /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
+  predictedCategory?: Maybe<TransactionCategory>;
+  /** Date predicted for tax/vat payment/refund predicted category */
+  predictedUserSelectedBookingDate?: Maybe<Scalars['DateTime']>;
   purpose?: Maybe<Scalars['String']>;
   documentNumber?: Maybe<Scalars['String']>;
   documentPreviewUrl?: Maybe<Scalars['String']>;
@@ -1416,6 +1419,10 @@ export type Transfer = {
   category?: Maybe<TransactionCategory>;
   /** When a transaction corresponds to a tax or vat payment, the user may specify at which date it should be considered booked */
   userSelectedBookingDate?: Maybe<Scalars['DateTime']>;
+  /** Predicted category for the SEPA Transfer */
+  predictedCategory?: Maybe<TransactionCategory>;
+  /** Date predicted for tax/vat payment/refund predicted category */
+  predictedUserSelectedBookingDate?: Maybe<Scalars['DateTime']>;
 };
 
 export type TransfersConnection = {

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -104,6 +104,8 @@ export const CATEGORIZE_TRANSACTION = `mutation categorizeTransaction(
     userSelectedBookingDate: $userSelectedBookingDate
   ) {
     ${TRANSACTION_FIELDS}
+    predictedCategory
+    predictedUserSelectedBookingDate
   }
 }`;
 

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -187,25 +187,38 @@ describe("Transaction", () => {
     });
 
     it("should call rawQuery and return updated transaction details", async () => {
+      const initialDate = new Date(0).toISOString();
+      const categorizationDate = new Date().toISOString();
+      const newCategory = TransactionCategory.TaxPayment;
       // arrange
       const transactionData = createTransaction({
         category: TransactionCategory.VatPayment,
-        userSelectedBookingDate: new Date().toISOString(),
+        userSelectedBookingDate: initialDate,
+        predictedCategory: TransactionCategory.VatPayment,
+        predictedUserSelectedBookingDate: initialDate,
       });
       stub.resolves({
-        categorizeTransaction: transactionData,
+        categorizeTransaction: {
+          ...transactionData,
+          category: newCategory,
+          userSelectedBookingDate: categorizationDate,
+        },
       } as any);
 
       // act
       const result = await client.models.transaction.categorize({
         id: transactionData.id,
-        category: TransactionCategory.VatPayment,
-        userSelectedBookingDate: new Date().toISOString(),
+        category: newCategory,
+        userSelectedBookingDate: categorizationDate,
       });
 
       // assert
       expect(stub.callCount).to.eq(1);
-      expect(result).to.deep.eq(transactionData);
+      expect(result).to.deep.eq({
+        ...transactionData,
+        category: newCategory,
+        userSelectedBookingDate: categorizationDate,
+      });
     });
   });
 


### PR DESCRIPTION
Respond with predicted category on categorize transaction response.

This mutation will be deprecated soon. I see that I should use extended https://github.com/kontist/js-sdk/pull/101 later.

Since predictedCategory will be used for now just for popup feature in mobile app, I decided to not include it in every transaction response.