### PR TITLE
Add resolvers and mutations for TransactionAssets

### DIFF
--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -17,7 +17,6 @@ export type Account = {|
   __typename?: 'Account',
   iban: $ElementType<Scalars, 'String'>,
   cardHolderRepresentation?: ?$ElementType<Scalars, 'String'>,
-  balance: $ElementType<Scalars, 'Int'>,
   canCreateOverdraft: $ElementType<Scalars, 'Boolean'>,
   cardHolderRepresentations: Array<$ElementType<Scalars, 'String'>>,
   transfers: TransfersConnection,
@@ -39,6 +38,7 @@ export type Account = {|
   overdraft?: ?Overdraft,
   /** Wirecard details */
   wirecard: WirecardDetails,
+  balance: $ElementType<Scalars, 'Int'>,
 |};
 
 
@@ -324,6 +324,13 @@ export type ConfirmFraudResponse = {|
   resolution: $ElementType<Scalars, 'String'>,
 |};
 
+export type CreateAssetResponse = {|
+  __typename?: 'CreateAssetResponse',
+  assetId: $ElementType<Scalars, 'ID'>,
+  url: $ElementType<Scalars, 'String'>,
+  formData: Array<FormDataPair>,
+|};
+
 /** The available fields to create an OAuth2 client */
 export type CreateClientInput = {|
   /** The name of the OAuth2 client displayed when users log in */
@@ -420,6 +427,12 @@ export const DocumentTypeValues = Object.freeze({
 
 
 export type DocumentType = $Values<typeof DocumentTypeValues>;
+
+export type FormDataPair = {|
+  __typename?: 'FormDataPair',
+  key: $ElementType<Scalars, 'String'>,
+  value: $ElementType<Scalars, 'String'>,
+|};
 
 export const GenderValues = Object.freeze({
   Male: 'MALE', 
@@ -555,6 +568,12 @@ export type Mutation = {|
   categorizeTransaction: Transaction,
   /** Categorize a transaction with an optional custom booking date for VAT or Tax categories, and add a personal note */
   updateTransaction: Transaction,
+  /** Create an TransactionAsset and obtain an upload config */
+  createTransactionAsset: CreateAssetResponse,
+  /** Confirm and validate an TransactionAsset upload as completed */
+  finalizeTransactionAssetUpload: TransactionAsset,
+  /** Remove an TransactionAsset from the Transaction and storage */
+  deleteTransactionAsset: MutationResult,
   /** Create Overdraft Application  - only available for Kontist Application */
   requestOverdraft?: ?Overdraft,
   /** Activate Overdraft Application  - only available for Kontist Application */
@@ -736,6 +755,23 @@ export type MutationUpdateTransactionArgs = {|
   category?: ?TransactionCategory,
   userSelectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
   personalNote?: ?$ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationCreateTransactionAssetArgs = {|
+  filetype: $ElementType<Scalars, 'String'>,
+  name: $ElementType<Scalars, 'String'>,
+  transactionId: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationFinalizeTransactionAssetUploadArgs = {|
+  assetId: $ElementType<Scalars, 'String'>,
+|};
+
+
+export type MutationDeleteTransactionAssetArgs = {|
+  assetId: $ElementType<Scalars, 'String'>,
 |};
 
 
@@ -1311,6 +1347,8 @@ export type Transaction = {|
   fees: Array<TransactionFee>,
   /** Metadata of separate pseudo-transactions created when splitting the parent transaction */
   splits: Array<TransactionSplit>,
+  /** List of uploaded Asset files for this transaction */
+  assets: Array<TransactionAsset>,
   /** The date at which the transaction was booked (created) */
   bookingDate: $ElementType<Scalars, 'DateTime'>,
   directDebitFees: Array<DirectDebitFee>,
@@ -1330,6 +1368,23 @@ export type Transaction = {|
   documentType?: ?DocumentType,
   foreignCurrency?: ?$ElementType<Scalars, 'String'>,
   originalAmount?: ?$ElementType<Scalars, 'Int'>,
+  /** View a single TransactionAsset for a transaction */
+  asset?: ?TransactionAsset,
+|};
+
+
+export type TransactionAssetArgs = {|
+  assetId: $ElementType<Scalars, 'ID'>,
+|};
+
+export type TransactionAsset = {|
+  __typename?: 'TransactionAsset',
+  id: $ElementType<Scalars, 'String'>,
+  name: $ElementType<Scalars, 'String'>,
+  filetype: $ElementType<Scalars, 'String'>,
+  path: $ElementType<Scalars, 'String'>,
+  thumbnail: $ElementType<Scalars, 'String'>,
+  fullsize: $ElementType<Scalars, 'String'>,
 |};
 
 export const TransactionCategoryValues = Object.freeze({

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -527,11 +527,11 @@ export type Mutation = {
   updateTransactionSplits: Transaction;
   /** Delete transaction splits */
   deleteTransactionSplits: Transaction;
-  /** Create transaction asset */
+  /** Create transaction asset, returning parameters required for upload */
   createTransactionAsset: CreateTransactionAssetMutationResult;
-  /** Create transaction asset */
+  /** Finalise + validate a transaction asset upload, returning the asset */
   finaliseTransactionAssetUpload: TransactionAsset;
-  /** Create transaction asset */
+  /** Delete transaction asset */
   deleteTransactionAsset: MutationResult;
   /** Subscribe user to a plan */
   subscribeToPlan: UserSubscription;

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -529,8 +529,8 @@ export type Mutation = {
   deleteTransactionSplits: Transaction;
   /** Create transaction asset, returning parameters required for upload */
   createTransactionAsset: CreateTransactionAssetMutationResult;
-  /** Finalise + validate a transaction asset upload, returning the asset */
-  finaliseTransactionAssetUpload: TransactionAsset;
+  /** Finalize + validate a transaction asset upload, returning the asset */
+  finalizeTransactionAssetUpload: TransactionAsset;
   /** Delete transaction asset */
   deleteTransactionAsset: MutationResult;
   /** Subscribe user to a plan */
@@ -736,7 +736,7 @@ export type CreateTransactionAssetMutationResult = {
   formData: { key: Scalars['String'], value: Scalars['String'] }[];
 };
 
-export type MutationFinaliseTransactionAssetArgs = {
+export type MutationFinalizeTransactionAssetArgs = {
   assetId: Scalars['ID'];
 };
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -527,6 +527,12 @@ export type Mutation = {
   updateTransactionSplits: Transaction;
   /** Delete transaction splits */
   deleteTransactionSplits: Transaction;
+  /** Create transaction asset */
+  createTransactionAsset: CreateTransactionAssetMutationResult;
+  /** Create transaction asset */
+  finaliseTransactionAssetUpload: TransactionAsset;
+  /** Create transaction asset */
+  deleteTransactionAsset: MutationResult;
   /** Subscribe user to a plan */
   subscribeToPlan: UserSubscription;
   /** Update user's subscription plan */
@@ -718,6 +724,25 @@ export type MutationDeleteTransactionSplitsArgs = {
   transactionId: Scalars['ID'];
 };
 
+export type MutationCreateTransactionAssetArgs = {
+  transactionId: Scalars['ID'];
+  name: Scalars['String'];
+  filetype: Scalars['String'];
+};
+
+export type CreateTransactionAssetMutationResult = {
+  assetId: Scalars['ID'];
+  url: Scalars['String'];
+  formData: { key: Scalars['String'], value: Scalars['String'] }[];
+};
+
+export type MutationFinaliseTransactionAssetArgs = {
+  assetId: Scalars['ID'];
+};
+
+export type MutationDeleteTransactionAssetArgs = {
+  assetId: Scalars['ID'];
+};
 
 export type MutationSubscribeToPlanArgs = {
   couponCode?: Maybe<Scalars['String']>;
@@ -1251,6 +1276,16 @@ export type Transaction = {
   documentType?: Maybe<DocumentType>;
   foreignCurrency?: Maybe<Scalars['String']>;
   originalAmount?: Maybe<Scalars['Int']>;
+  assets: Array<TransactionAsset>;
+};
+
+export type TransactionAsset = {
+  __typename?: 'TransactionAsset';
+  id: Scalars['ID'];
+  name: Maybe<Scalars['String']>;
+  filetype: Maybe<Scalars['String']>;
+  thumbnail: Maybe<Scalars['String']>;
+  fullsize: Maybe<Scalars['String']>;
 };
 
 export enum TransactionCategory {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -15,7 +15,6 @@ export type Account = {
   __typename?: 'Account';
   iban: Scalars['String'];
   cardHolderRepresentation?: Maybe<Scalars['String']>;
-  balance: Scalars['Int'];
   canCreateOverdraft: Scalars['Boolean'];
   cardHolderRepresentations: Array<Scalars['String']>;
   transfers: TransfersConnection;
@@ -40,6 +39,7 @@ export type Account = {
    * @deprecated This data will be removed in an upcoming release. Do not use it for any new features.
    */
   wirecard: WirecardDetails;
+  balance: Scalars['Int'];
 };
 
 
@@ -298,6 +298,13 @@ export type ConfirmFraudResponse = {
   resolution: Scalars['String'];
 };
 
+export type CreateAssetResponse = {
+  __typename?: 'CreateAssetResponse';
+  assetId: Scalars['ID'];
+  url: Scalars['String'];
+  formData: Array<FormDataPair>;
+};
+
 /** The available fields to create an OAuth2 client */
 export type CreateClientInput = {
   /** The name of the OAuth2 client displayed when users log in */
@@ -391,6 +398,12 @@ export enum DocumentType {
   Voucher = 'VOUCHER',
   Invoice = 'INVOICE'
 }
+
+export type FormDataPair = {
+  __typename?: 'FormDataPair';
+  key: Scalars['String'];
+  value: Scalars['String'];
+};
 
 export enum Gender {
   Male = 'MALE',
@@ -512,6 +525,12 @@ export type Mutation = {
   categorizeTransaction: Transaction;
   /** Categorize a transaction with an optional custom booking date for VAT or Tax categories, and add a personal note */
   updateTransaction: Transaction;
+  /** Create an TransactionAsset and obtain an upload config */
+  createTransactionAsset: CreateAssetResponse;
+  /** Confirm and validate an TransactionAsset upload as completed */
+  finalizeTransactionAssetUpload: TransactionAsset;
+  /** Remove an TransactionAsset from the Transaction and storage */
+  deleteTransactionAsset: MutationResult;
   /** Create Overdraft Application  - only available for Kontist Application */
   requestOverdraft?: Maybe<Overdraft>;
   /** Activate Overdraft Application  - only available for Kontist Application */
@@ -527,12 +546,6 @@ export type Mutation = {
   updateTransactionSplits: Transaction;
   /** Delete transaction splits */
   deleteTransactionSplits: Transaction;
-  /** Create transaction asset, returning parameters required for upload */
-  createTransactionAsset: CreateTransactionAssetMutationResult;
-  /** Finalize + validate a transaction asset upload, returning the asset */
-  finalizeTransactionAssetUpload: TransactionAsset;
-  /** Delete transaction asset */
-  deleteTransactionAsset: MutationResult;
   /** Subscribe user to a plan */
   subscribeToPlan: UserSubscription;
   /** Update user's subscription plan */
@@ -702,6 +715,23 @@ export type MutationUpdateTransactionArgs = {
 };
 
 
+export type MutationCreateTransactionAssetArgs = {
+  filetype: Scalars['String'];
+  name: Scalars['String'];
+  transactionId: Scalars['String'];
+};
+
+
+export type MutationFinalizeTransactionAssetUploadArgs = {
+  assetId: Scalars['String'];
+};
+
+
+export type MutationDeleteTransactionAssetArgs = {
+  assetId: Scalars['String'];
+};
+
+
 export type MutationUpdateOverdraftArgs = {
   offeredScreenShown?: Maybe<Scalars['Boolean']>;
   rejectionScreenShown?: Maybe<Scalars['Boolean']>;
@@ -724,25 +754,6 @@ export type MutationDeleteTransactionSplitsArgs = {
   transactionId: Scalars['ID'];
 };
 
-export type MutationCreateTransactionAssetArgs = {
-  transactionId: Scalars['ID'];
-  name: Scalars['String'];
-  filetype: Scalars['String'];
-};
-
-export type CreateTransactionAssetMutationResult = {
-  assetId: Scalars['ID'];
-  url: Scalars['String'];
-  formData: { key: Scalars['String'], value: Scalars['String'] }[];
-};
-
-export type MutationFinalizeTransactionAssetArgs = {
-  assetId: Scalars['ID'];
-};
-
-export type MutationDeleteTransactionAssetArgs = {
-  assetId: Scalars['ID'];
-};
 
 export type MutationSubscribeToPlanArgs = {
   couponCode?: Maybe<Scalars['String']>;
@@ -1257,6 +1268,8 @@ export type Transaction = {
   fees: Array<TransactionFee>;
   /** Metadata of separate pseudo-transactions created when splitting the parent transaction */
   splits: Array<TransactionSplit>;
+  /** List of uploaded Asset files for this transaction */
+  assets: Array<TransactionAsset>;
   /** The date at which the transaction was booked (created) */
   bookingDate: Scalars['DateTime'];
   directDebitFees: Array<DirectDebitFee>;
@@ -1276,16 +1289,23 @@ export type Transaction = {
   documentType?: Maybe<DocumentType>;
   foreignCurrency?: Maybe<Scalars['String']>;
   originalAmount?: Maybe<Scalars['Int']>;
-  assets: Array<TransactionAsset>;
+  /** View a single TransactionAsset for a transaction */
+  asset?: Maybe<TransactionAsset>;
+};
+
+
+export type TransactionAssetArgs = {
+  assetId: Scalars['ID'];
 };
 
 export type TransactionAsset = {
   __typename?: 'TransactionAsset';
-  id: Scalars['ID'];
-  name: Maybe<Scalars['String']>;
-  filetype: Maybe<Scalars['String']>;
-  thumbnail: Maybe<Scalars['String']>;
-  fullsize: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  name: Scalars['String'];
+  filetype: Scalars['String'];
+  path: Scalars['String'];
+  thumbnail: Scalars['String'];
+  fullsize: Scalars['String'];
 };
 
 export enum TransactionCategory {

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -9,7 +9,7 @@ import {
   MutationDeleteTransactionSplitsArgs,
   MutationUpdateTransactionSplitsArgs,
   MutationCreateTransactionAssetArgs,
-  MutationFinalizeTransactionAssetArgs,
+  MutationFinalizeTransactionAssetUploadArgs,
   MutationDeleteTransactionAssetArgs,
   Query,
   Transaction as TransactionModel,
@@ -339,7 +339,7 @@ export class Transaction extends IterableModel<TransactionModel> {
    * @param args   asset ID
    * @returns      the finalized TransactionAsset information
    */
-  public async finalizeTransactionAssetUpload(args: MutationFinalizeTransactionAssetArgs) {
+  public async finalizeTransactionAssetUpload(args: MutationFinalizeTransactionAssetUploadArgs) {
     const result = await this.client.rawQuery(FINALIZE_TRANSACTION_ASSET, args);
     return result.finalizeTransactionAssetUpload;
   }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -8,6 +8,9 @@ import {
   MutationCreateTransactionSplitsArgs,
   MutationDeleteTransactionSplitsArgs,
   MutationUpdateTransactionSplitsArgs,
+  MutationCreateTransactionAssetArgs,
+  MutationFinaliseTransactionAssetArgs,
+  MutationDeleteTransactionAssetArgs,
   Query,
   Transaction as TransactionModel,
   TransactionFilter,
@@ -37,6 +40,14 @@ type AmountSearchFilter = {
   conditions: AmountBetweenFilter[];
 };
 
+const ASSET_FIELDS = `
+  id
+  name
+  filetype
+  thumbnail
+  fullsize
+`;
+
 const TRANSACTION_FIELDS = `
   id
   amount
@@ -64,6 +75,9 @@ const TRANSACTION_FIELDS = `
     amount
     category
     userSelectedBookingDate
+  }
+  assets {
+    ${ASSET_FIELDS}
   }
 `;
 
@@ -158,6 +172,46 @@ export const UPDATE_SPLIT_TRANSACTION = `mutation updateTransactionSplits(
     ${TRANSACTION_FIELDS}
   }
 }`;
+
+export const CREATE_TRANSACTION_ASSET = `mutation createTransactionAsset(
+  $transactionId: ID!
+  $name: String!
+  $filetype: String!
+) {
+  createTransactionAsset(
+    transactionId: $transactionId
+    name: $name
+    filetype: $filetype
+  ) {
+    assetId
+    url
+    formData {
+      key
+      value
+    }
+  }
+}`;
+
+export const FINALISE_TRANSACTION_ASSET = `mutation finaliseTransactionAssetUpload(
+  $assetId: ID!
+) {
+  finaliseTransactionAssetUpload(
+    assetId: $assetId
+  ) {
+    ${ASSET_FIELDS}
+  }
+}`;
+
+export const DELETE_TRANSACTION_ASSET = `mutation deleteTransactionAsset(
+  $assetId: ID!
+) {
+  deleteTransactionAsset(
+    assetId: $assetId
+  ) {
+    successs
+  }
+}`;
+
 
 export class Transaction extends IterableModel<TransactionModel> {
   /**
@@ -267,6 +321,39 @@ export class Transaction extends IterableModel<TransactionModel> {
   public async updateSplit(args: MutationUpdateTransactionSplitsArgs) {
     const result = await this.client.rawQuery(UPDATE_SPLIT_TRANSACTION, args);
     return result.updateTransactionSplits;
+  }
+
+  /**
+   * Creates upload parameters for uploading a TransactionAsset file
+   *
+   * @param args   transaction ID, name, and filetype
+   * @returns      the required data to upload a file
+   */
+  public async createTransactionAsset(args: MutationCreateTransactionAssetArgs) {
+    const result = await this.client.rawQuery(CREATE_TRANSACTION_ASSET, args);
+    return result.createTransactionAsset;
+  }
+
+  /**
+   * Verifies and marks a TransactionAsset file as ready
+   *
+   * @param args   asset ID
+   * @returns      the finalised TransactionAsset information
+   */
+  public async finaliseTransactionAssetUpload(args: MutationFinaliseTransactionAssetArgs) {
+    const result = await this.client.rawQuery(FINALISE_TRANSACTION_ASSET, args);
+    return result.finaliseTransactionAssetUpload;
+  }
+
+  /**
+   * Deletes a TransactionAsset
+   *
+   * @param args   asset ID
+   * @returns      the finalised TransactionAsset information
+   */
+  public async deleteTransactionAsset(args: MutationDeleteTransactionAssetArgs) {
+    const result = await this.client.rawQuery(DELETE_TRANSACTION_ASSET, args);
+    return result.deleteTransactionAsset;
   }
 
   private parseAmountSearchTerm(amountTerm: string): AmountSearchFilter {

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -9,7 +9,7 @@ import {
   MutationDeleteTransactionSplitsArgs,
   MutationUpdateTransactionSplitsArgs,
   MutationCreateTransactionAssetArgs,
-  MutationFinaliseTransactionAssetArgs,
+  MutationFinalizeTransactionAssetArgs,
   MutationDeleteTransactionAssetArgs,
   Query,
   Transaction as TransactionModel,
@@ -192,10 +192,10 @@ export const CREATE_TRANSACTION_ASSET = `mutation createTransactionAsset(
   }
 }`;
 
-export const FINALISE_TRANSACTION_ASSET = `mutation finaliseTransactionAssetUpload(
+export const FINALIZE_TRANSACTION_ASSET = `mutation finalizeTransactionAssetUpload(
   $assetId: ID!
 ) {
-  finaliseTransactionAssetUpload(
+  finalizeTransactionAssetUpload(
     assetId: $assetId
   ) {
     ${ASSET_FIELDS}
@@ -211,7 +211,6 @@ export const DELETE_TRANSACTION_ASSET = `mutation deleteTransactionAsset(
     successs
   }
 }`;
-
 
 export class Transaction extends IterableModel<TransactionModel> {
   /**
@@ -338,18 +337,18 @@ export class Transaction extends IterableModel<TransactionModel> {
    * Verifies and marks a TransactionAsset file as ready
    *
    * @param args   asset ID
-   * @returns      the finalised TransactionAsset information
+   * @returns      the finalized TransactionAsset information
    */
-  public async finaliseTransactionAssetUpload(args: MutationFinaliseTransactionAssetArgs) {
-    const result = await this.client.rawQuery(FINALISE_TRANSACTION_ASSET, args);
-    return result.finaliseTransactionAssetUpload;
+  public async finalizeTransactionAssetUpload(args: MutationFinalizeTransactionAssetArgs) {
+    const result = await this.client.rawQuery(FINALIZE_TRANSACTION_ASSET, args);
+    return result.finalizeTransactionAssetUpload;
   }
 
   /**
    * Deletes a TransactionAsset
    *
    * @param args   asset ID
-   * @returns      the finalised TransactionAsset information
+   * @returns      a MutationResult
    */
   public async deleteTransactionAsset(args: MutationDeleteTransactionAssetArgs) {
     const result = await this.client.rawQuery(DELETE_TRANSACTION_ASSET, args);

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -9,7 +9,7 @@ import {
   UPDATE_SPLIT_TRANSACTION,
 
   CREATE_TRANSACTION_ASSET,
-  FINALISE_TRANSACTION_ASSET,
+  FINALIZE_TRANSACTION_ASSET,
   DELETE_TRANSACTION_ASSET
 } from "../../lib/graphql/transaction";
 import { SubscriptionType } from "../../lib/graphql/types";
@@ -484,7 +484,7 @@ describe("Transaction", () => {
     });
   });
 
-  describe("#finaliseTransactionAssetUpload", () => {
+  describe("#finalizeTransactionAssetUpload", () => {
     let client: Client;
     let stub: any;
 
@@ -507,16 +507,16 @@ describe("Transaction", () => {
       };
 
       stub.resolves({
-        finaliseTransactionAssetUpload: asset,
+        finalizeTransactionAssetUpload: asset,
       } as any);
 
-      const result = await client.models.transaction.finaliseTransactionAssetUpload({
+      const result = await client.models.transaction.finalizeTransactionAssetUpload({
         assetId: asset.id
       });
 
       // assert: check for valid rawQuery number of calls and proper arguments + expected result
       expect(stub.callCount).to.eq(1);
-      expect(stub.args[0][0]).to.eq(FINALISE_TRANSACTION_ASSET,
+      expect(stub.args[0][0]).to.eq(FINALIZE_TRANSACTION_ASSET,
         DELETE_TRANSACTION_ASSET);
       expect(stub.args[0][1]).to.deep.eq({ assetId: asset.id });
       expect(result).to.deep.eq(asset);

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -470,7 +470,6 @@ describe("Transaction", () => {
         createTransactionAsset: expectedResult,
       } as any);
 
-      // act: update transaction with prepared split data
       const result = await client.models.transaction.createTransactionAsset({
         transactionId: transaction.id,
         name: "test",
@@ -511,7 +510,6 @@ describe("Transaction", () => {
         finaliseTransactionAssetUpload: asset,
       } as any);
 
-      // act: update transaction with prepared split data
       const result = await client.models.transaction.finaliseTransactionAssetUpload({
         assetId: asset.id
       });
@@ -545,7 +543,6 @@ describe("Transaction", () => {
         deleteTransactionAsset: { success: true },
       } as any);
 
-      // act: update transaction with prepared split data
       const result = await client.models.transaction.deleteTransactionAsset({ assetId });
 
       // assert: check for valid rawQuery number of calls and proper arguments + expected result

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -33,6 +33,7 @@ export const createTransaction = (
     paymentMethod: "card",
     type: TransactionProjectionType.Atm,
     splits: [],
+    assets: [],
     createdAt: new Date(0).toISOString(),
     ...override,
   };


### PR DESCRIPTION
This adds the `assets` resolver to the `transaction` response.

It also adds the mutation helpers:
* `createTransactionAsset({ transactionId, name, filetype })`
* `finaliseTransactionAssetUpload({ assetId })`
* `deleteTransactionAsset({ assetId })`