### PR TITLE
Use correct type for transactionId/assetId in transaction asset mutations

### DIFF
--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -766,17 +766,17 @@ export type MutationUpdateTransactionArgs = {|
 export type MutationCreateTransactionAssetArgs = {|
   filetype: $ElementType<Scalars, 'String'>,
   name: $ElementType<Scalars, 'String'>,
-  transactionId: $ElementType<Scalars, 'String'>,
+  transactionId: $ElementType<Scalars, 'ID'>,
 |};
 
 
 export type MutationFinalizeTransactionAssetUploadArgs = {|
-  assetId: $ElementType<Scalars, 'String'>,
+  assetId: $ElementType<Scalars, 'ID'>,
 |};
 
 
 export type MutationDeleteTransactionAssetArgs = {|
-  assetId: $ElementType<Scalars, 'String'>,
+  assetId: $ElementType<Scalars, 'ID'>,
 |};
 
 
@@ -1914,3 +1914,4 @@ export type WirecardDetails = {|
   hasAccount: $ElementType<Scalars, 'Boolean'>,
   plasticCardOrderedAt?: ?$ElementType<Scalars, 'DateTime'>,
 |};
+

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -724,17 +724,17 @@ export type MutationUpdateTransactionArgs = {
 export type MutationCreateTransactionAssetArgs = {
   filetype: Scalars['String'];
   name: Scalars['String'];
-  transactionId: Scalars['String'];
+  transactionId: Scalars['ID'];
 };
 
 
 export type MutationFinalizeTransactionAssetUploadArgs = {
-  assetId: Scalars['String'];
+  assetId: Scalars['ID'];
 };
 
 
 export type MutationDeleteTransactionAssetArgs = {
-  assetId: Scalars['String'];
+  assetId: Scalars['ID'];
 };
 
 


### PR DESCRIPTION
Related to https://github.com/kontist/backend/pull/7576