### PR TITLE
Fix a typo (successs -> success) in deleteTransactionAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Resolve schema issues with transaction assets
 
 ## [0.30.0] - 2020-07-08
 

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -208,7 +208,7 @@ export const DELETE_TRANSACTION_ASSET = `mutation deleteTransactionAsset(
   deleteTransactionAsset(
     assetId: $assetId
   ) {
-    successs
+    success
   }
 }`;
 


### PR DESCRIPTION
As reported by @RodionChachura, this typo causes an error to be thrown when using deleteTransactionAsset.