### PR TITLE
Move graphql back to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.30.2",
+  "version": "0.31.0",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
@@ -19,6 +19,7 @@
     "client-oauth2": "^4.3.0",
     "cross-fetch": "^3.0.5",
     "dotenv": "^8.2.0",
+    "graphql": "^15.3.0",
     "graphql-request": "^2.1.0-next.1",
     "js-sha256": "^0.9.0",
     "subscriptions-transport-ws": "^0.9.16",
@@ -36,7 +37,6 @@
     "@types/ws": "^7.2.6",
     "chai": "^4.2.0",
     "copy-webpack-plugin": "^6.0.3",
-    "graphql": "^15.3.0",
     "jsdom": "^16.3.0",
     "mocha": "^8.0.1",
     "moment": "^2.27.0",


### PR DESCRIPTION
`graphql` is depended as a peer dependency by `subscriptions-transport-ws`

Moving it to devDependencies breaks the library.