### PR TITLE
Add fetchOne helper for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- *Breaking*: removed several transaction fields from the results of the fetch and fetchAll transaction methods (see `TRANSACTION_DETAILS` in `lib/graphql/transaction` for the details) [#132](https://github.com/kontist/js-sdk/pull/132)
+
+### Added
+- Added `fetchOne` method on transaction model which will return all transaction fields for a given transaction ID [#132](https://github.com/kontist/js-sdk/pull/132)
+
 ## [0.31.3] - 2020-07-16
 
 ### Added

--- a/tests/graphql/transaction.spec.ts
+++ b/tests/graphql/transaction.spec.ts
@@ -169,7 +169,7 @@ describe("Transaction", () => {
       };
       transactionInstance = new TransactionClass(graphqlClientStub as any);
     });
-  
+
     describe("when there is no result", () => {
       before(async () => {
         graphqlClientStub.rawQuery.reset();
@@ -182,6 +182,52 @@ describe("Transaction", () => {
         expect(result.items).to.eql([]);
         expect(result.pageInfo.hasNextPage).to.eql(false);
         expect(result.pageInfo.hasPreviousPage).to.eql(false);
+      });
+    });
+  });
+
+  describe("#fetchOne", () => {
+    let graphqlClientStub: { rawQuery: sinon.SinonStub };
+    let transactionInstance: TransactionClass;
+    let result: any;
+
+    before(() => {
+      graphqlClientStub = {
+        rawQuery: sinon.stub(),
+      };
+      transactionInstance = new TransactionClass(graphqlClientStub as any);
+    });
+
+    describe("when transaction is not found", () => {
+      before(async () => {
+        graphqlClientStub.rawQuery.reset();
+        graphqlClientStub.rawQuery.resolves({
+          viewer: { mainAccount: { transaction: null } },
+        });
+        result = await transactionInstance.fetchOne({ id: "some-id" });
+      });
+
+      it("should return null", () => {
+        expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
+        expect(result).to.eql(null);
+      });
+    });
+
+    describe("when transaction is found", () => {
+      let transaction: Transaction;
+
+      before(async () => {
+        transaction = createTransaction();
+        graphqlClientStub.rawQuery.reset();
+        graphqlClientStub.rawQuery.resolves({
+          viewer: { mainAccount: { transaction } },
+        });
+        result = await transactionInstance.fetchOne({ id: transaction.id });
+      });
+
+      it("should return the fetched transaction", () => {
+        expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
+        expect(result).to.eql(transaction);
       });
     });
   });


### PR DESCRIPTION
I would like to reduce the number of fields returned by the `fetch` transaction method. Presently it returns quite a few things that are not necessary as it is only used for the transaction list.

Goal is to improve app and backend performance. Already changing this will incur one less db call *per transaction* each time the transaction list is fetched. 
Later we will be able to further reduce it by tweaking backend to only join additional models when necessary instead of always naively joining all the time.

I added a fetchOne counterpart which would return all fields. In theory we will be able to use it in the native app instead of having a raw query.