### PR TITLE
Build correct verifier

### DIFF
--- a/lib/auth/tokenManager.ts
+++ b/lib/auth/tokenManager.ts
@@ -52,8 +52,8 @@ export class TokenManager {
         btoa(String.fromCharCode.apply(null, sha256.array(this.verifier)))!
 
         .split("=")[0]
-        .replace("+", "-")
-        .replace("/", "_");
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_");
 
       query.code_challenge = challenge;
       query.code_challenge_method = "S256";


### PR DESCRIPTION
This PR addresses an issue where a user could not log in.
Reason was an incorrect implementation of the https://tools.ietf.org/html/rfc7636#appendix-A algorithm.

To be specific - the log in failed every time when the code challenge contained more than one character of "+" or "/".

`replace` is not `replaceAll`
