### PR TITLE
Extend get_user query with ScreeningStatus

### DIFF
--- a/lib/graphql/user.ts
+++ b/lib/graphql/user.ts
@@ -18,6 +18,7 @@ const GET_USER = `query {
     gender
     identificationLink
     identificationStatus
+    screeningStatus
     isUSPerson
     lastName
     mobileNumber


### PR DESCRIPTION
Extends the `get_user` query with `screeningStatus` so that the screeningStatus is included in the response when getting user details. The `screeningStatus` is set to `null` by default for all users, so it should be available for all users when running the get_user query.

This also fix the failing `services/backendService/src/test/sdk/graphql/user.test.ts` test in the BE repo: https://github.com/kontist/backend/pull/10129