### PR TITLE
Rename elsterCode to categoryCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.36.0] - 2021-08-13
+### Changed
+- Replace `elsterCode` by `categoryCode`. Keep `elsterCode` for backward compatibility.
+
 ## [0.35.41] - 2021-06-29
 - Remove deprecated `categorizeTransaction` mutation
 ### Added

--- a/lib/graphql/declaration.ts
+++ b/lib/graphql/declaration.ts
@@ -73,15 +73,15 @@ const GET_DECLARATION_STATS = `
             valutaDate
             selectedBookingDate
             category
-            elsterCode
+            categoryCode
             vatRate
             vatAmount
             isSplit
           }
-          elsterGroups {
+          categoryGroups {
             amount
-            elsterCode
-            elsterCodeTranslation
+            categoryCode
+            categoryCodeTranslation
             transactions {
               id
               amount
@@ -90,7 +90,7 @@ const GET_DECLARATION_STATS = `
               valutaDate
               selectedBookingDate
               category
-              elsterCode
+              categoryCode
               vatRate
               vatAmount
               isSplit
@@ -105,19 +105,19 @@ const GET_DECLARATION_STATS = `
 const CATEGORIZE_TRANSACTION_MUTATION = `mutation(
   $id: ID!,
   $category: TransactionCategory,
-  $elsterCode: String,
+  $categoryCode: String,
   $date: String
   $isSplit: Boolean
 ) {
   categorizeTransactionForDeclaration(
     id: $id,
     category: $category,
-    elsterCode: $elsterCode
+    categoryCode: $categoryCode
     date: $date
     isSplit: $isSplit
   ) {
     category
-    elsterCode
+    categoryCode
     date
   }
 }`;

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1929,6 +1929,7 @@ export type Transaction = {|
   foreignCurrency?: ?$ElementType<Scalars, 'String'>,
   originalAmount?: ?$ElementType<Scalars, 'Int'>,
   categoryCode?: ?$ElementType<Scalars, 'String'>,
+  elsterCode?: ?$ElementType<Scalars, 'String'>,
   categoryCodeTranslation?: ?$ElementType<Scalars, 'String'>,
   elsterCodeTranslation?: ?$ElementType<Scalars, 'String'>,
   recurlyInvoiceNumber?: ?$ElementType<Scalars, 'String'>,

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -333,9 +333,20 @@ export type CategorizationType = $Values<typeof CategorizationTypeValues>;
 
 export type CategorizeTransactionForDeclarationResponse = {|
   __typename?: 'CategorizeTransactionForDeclarationResponse',
+  categoryCode?: ?$ElementType<Scalars, 'String'>,
   elsterCode?: ?$ElementType<Scalars, 'String'>,
   category?: ?$ElementType<Scalars, 'String'>,
   date?: ?$ElementType<Scalars, 'String'>,
+|};
+
+export type CategoryGroup = {|
+  __typename?: 'CategoryGroup',
+  categoryCode: $ElementType<Scalars, 'String'>,
+  elsterCode: $ElementType<Scalars, 'String'>,
+  amount: $ElementType<Scalars, 'Int'>,
+  categoryCodeTranslation: $ElementType<Scalars, 'String'>,
+  elsterCodeTranslation: $ElementType<Scalars, 'String'>,
+  transactions: Array<TransactionForAccountingView>,
 |};
 
 export type Client = {|
@@ -522,7 +533,8 @@ export type Declaration = {|
 export type DeclarationStats = {|
   __typename?: 'DeclarationStats',
   amount: $ElementType<Scalars, 'Int'>,
-  elsterGroups: Array<ElsterGroup>,
+  categoryGroups: Array<CategoryGroup>,
+  elsterGroups: Array<CategoryGroup>,
   uncategorized: Array<TransactionForAccountingView>,
 |};
 
@@ -563,14 +575,6 @@ export const DocumentTypeValues = Object.freeze({
 
 
 export type DocumentType = $Values<typeof DocumentTypeValues>;
-
-export type ElsterGroup = {|
-  __typename?: 'ElsterGroup',
-  elsterCode: $ElementType<Scalars, 'String'>,
-  amount: $ElementType<Scalars, 'Int'>,
-  elsterCodeTranslation: $ElementType<Scalars, 'String'>,
-  transactions: Array<TransactionForAccountingView>,
-|};
 
 export type FormDataPair = {|
   __typename?: 'FormDataPair',
@@ -1257,6 +1261,7 @@ export type MutationUpsertProductsArgs = {|
 
 export type MutationCategorizeTransactionForDeclarationArgs = {|
   id: $ElementType<Scalars, 'ID'>,
+  categoryCode?: ?$ElementType<Scalars, 'String'>,
   elsterCode?: ?$ElementType<Scalars, 'String'>,
   category?: ?TransactionCategory,
   date?: ?$ElementType<Scalars, 'String'>,
@@ -1923,7 +1928,8 @@ export type Transaction = {|
   documentType?: ?DocumentType,
   foreignCurrency?: ?$ElementType<Scalars, 'String'>,
   originalAmount?: ?$ElementType<Scalars, 'Int'>,
-  elsterCode?: ?$ElementType<Scalars, 'String'>,
+  categoryCode?: ?$ElementType<Scalars, 'String'>,
+  categoryCodeTranslation?: ?$ElementType<Scalars, 'String'>,
   elsterCodeTranslation?: ?$ElementType<Scalars, 'String'>,
   recurlyInvoiceNumber?: ?$ElementType<Scalars, 'String'>,
   /** List Assets for a transaction */
@@ -2093,6 +2099,7 @@ export type TransactionForAccountingView = {|
   valutaDate: $ElementType<Scalars, 'DateTime'>,
   selectedBookingDate?: ?$ElementType<Scalars, 'DateTime'>,
   category?: ?TransactionCategory,
+  categoryCode?: ?$ElementType<Scalars, 'String'>,
   elsterCode?: ?$ElementType<Scalars, 'String'>,
   vatRate?: ?$ElementType<Scalars, 'String'>,
   vatAmount?: ?$ElementType<Scalars, 'Int'>,
@@ -2151,7 +2158,10 @@ export const TransactionProjectionTypeValues = Object.freeze({
   RebookedSepaCreditTransferReturn: 'RebookedSEPACreditTransferReturn',
   ChargeRecallRequest: 'ChargeRecallRequest',
   CorrectionSepaCreditTransfer: 'CorrectionSEPACreditTransfer',
-  InterestExcessDeposit: 'InterestExcessDeposit'
+  InterestExcessDeposit: 'InterestExcessDeposit',
+  InterestOverdraft: 'InterestOverdraft',
+  InterestOverdraftExceeded: 'InterestOverdraftExceeded',
+  ReimbursementCustomer: 'ReimbursementCustomer'
 });
 
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -308,9 +308,20 @@ export enum CategorizationType {
 
 export type CategorizeTransactionForDeclarationResponse = {
   __typename?: 'CategorizeTransactionForDeclarationResponse';
+  categoryCode?: Maybe<Scalars['String']>;
   elsterCode?: Maybe<Scalars['String']>;
   category?: Maybe<Scalars['String']>;
   date?: Maybe<Scalars['String']>;
+};
+
+export type CategoryGroup = {
+  __typename?: 'CategoryGroup';
+  categoryCode: Scalars['String'];
+  elsterCode: Scalars['String'];
+  amount: Scalars['Int'];
+  categoryCodeTranslation: Scalars['String'];
+  elsterCodeTranslation: Scalars['String'];
+  transactions: Array<TransactionForAccountingView>;
 };
 
 export type Client = {
@@ -494,7 +505,8 @@ export type Declaration = {
 export type DeclarationStats = {
   __typename?: 'DeclarationStats';
   amount: Scalars['Int'];
-  elsterGroups: Array<ElsterGroup>;
+  categoryGroups: Array<CategoryGroup>;
+  elsterGroups: Array<CategoryGroup>;
   uncategorized: Array<TransactionForAccountingView>;
 };
 
@@ -529,14 +541,6 @@ export enum DocumentType {
   Voucher = 'VOUCHER',
   Invoice = 'INVOICE'
 }
-
-export type ElsterGroup = {
-  __typename?: 'ElsterGroup';
-  elsterCode: Scalars['String'];
-  amount: Scalars['Int'];
-  elsterCodeTranslation: Scalars['String'];
-  transactions: Array<TransactionForAccountingView>;
-};
 
 export type FormDataPair = {
   __typename?: 'FormDataPair';
@@ -1196,6 +1200,7 @@ export type MutationUpsertProductsArgs = {
 
 export type MutationCategorizeTransactionForDeclarationArgs = {
   id: Scalars['ID'];
+  categoryCode?: Maybe<Scalars['String']>;
   elsterCode?: Maybe<Scalars['String']>;
   category?: Maybe<TransactionCategory>;
   date?: Maybe<Scalars['String']>;
@@ -1811,7 +1816,8 @@ export type Transaction = {
   documentType?: Maybe<DocumentType>;
   foreignCurrency?: Maybe<Scalars['String']>;
   originalAmount?: Maybe<Scalars['Int']>;
-  elsterCode?: Maybe<Scalars['String']>;
+  categoryCode?: Maybe<Scalars['String']>;
+  categoryCodeTranslation?: Maybe<Scalars['String']>;
   elsterCodeTranslation?: Maybe<Scalars['String']>;
   recurlyInvoiceNumber?: Maybe<Scalars['String']>;
   /** List Assets for a transaction */
@@ -1972,6 +1978,7 @@ export type TransactionForAccountingView = {
   valutaDate: Scalars['DateTime'];
   selectedBookingDate?: Maybe<Scalars['DateTime']>;
   category?: Maybe<TransactionCategory>;
+  categoryCode?: Maybe<Scalars['String']>;
   elsterCode?: Maybe<Scalars['String']>;
   vatRate?: Maybe<Scalars['String']>;
   vatAmount?: Maybe<Scalars['Int']>;
@@ -2030,7 +2037,10 @@ export enum TransactionProjectionType {
   RebookedSepaCreditTransferReturn = 'RebookedSEPACreditTransferReturn',
   ChargeRecallRequest = 'ChargeRecallRequest',
   CorrectionSepaCreditTransfer = 'CorrectionSEPACreditTransfer',
-  InterestExcessDeposit = 'InterestExcessDeposit'
+  InterestExcessDeposit = 'InterestExcessDeposit',
+  InterestOverdraft = 'InterestOverdraft',
+  InterestOverdraftExceeded = 'InterestOverdraftExceeded',
+  ReimbursementCustomer = 'ReimbursementCustomer'
 }
 
 export type TransactionSplit = {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1817,6 +1817,7 @@ export type Transaction = {
   foreignCurrency?: Maybe<Scalars['String']>;
   originalAmount?: Maybe<Scalars['Int']>;
   categoryCode?: Maybe<Scalars['String']>;
+  elsterCode?: Maybe<Scalars['String']>;
   categoryCodeTranslation?: Maybe<Scalars['String']>;
   elsterCodeTranslation?: Maybe<Scalars['String']>;
   recurlyInvoiceNumber?: Maybe<Scalars['String']>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.35.47",
+  "version": "0.36.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.35.47",
+      "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.35.47",
+  "version": "0.36.0",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/auth/tokenManager.spec.ts
+++ b/tests/auth/tokenManager.spec.ts
@@ -14,7 +14,7 @@ describe("Auth: TokenManager", () => {
     it("should return proper redirect url when clientSecret is provided", async () => {
       const client = createClient({ clientSecret });
       const url = await client.auth.tokenManager.getAuthUri();
-      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&scope=transactions&response_type=code&state=25843739712322056`;
+      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&response_type=code&state=25843739712322056&scope=transactions`;
       expect(url).to.equal(expectedUrl);
     });
 
@@ -23,7 +23,7 @@ describe("Auth: TokenManager", () => {
       const codeChallenge = "xc3uY4-XMuobNWXzzfEqbYx3rUYBH69_zu4EFQIJH8w";
       const codeChallengeMethod = "S256";
       const url = await client.auth.tokenManager.getAuthUri();
-      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&scope=transactions&response_type=code&state=25843739712322056&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}`;
+      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&response_type=code&state=25843739712322056&scope=transactions&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}`;
       expect(url).to.equal(expectedUrl);
     });
   });

--- a/tests/auth/tokenManager.spec.ts
+++ b/tests/auth/tokenManager.spec.ts
@@ -14,7 +14,7 @@ describe("Auth: TokenManager", () => {
     it("should return proper redirect url when clientSecret is provided", async () => {
       const client = createClient({ clientSecret });
       const url = await client.auth.tokenManager.getAuthUri();
-      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&response_type=code&state=25843739712322056&scope=transactions`;
+      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&scope=transactions&response_type=code&state=25843739712322056`;
       expect(url).to.equal(expectedUrl);
     });
 
@@ -23,7 +23,7 @@ describe("Auth: TokenManager", () => {
       const codeChallenge = "xc3uY4-XMuobNWXzzfEqbYx3rUYBH69_zu4EFQIJH8w";
       const codeChallengeMethod = "S256";
       const url = await client.auth.tokenManager.getAuthUri();
-      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&response_type=code&state=25843739712322056&scope=transactions&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}`;
+      const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&scope=transactions&response_type=code&state=25843739712322056&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}`;
       expect(url).to.equal(expectedUrl);
     });
   });

--- a/tests/graphql/declaration.spec.ts
+++ b/tests/graphql/declaration.spec.ts
@@ -134,7 +134,7 @@ describe("Declaration", () => {
             {
               amount: 3,
               category: null,
-              elsterCode: null,
+              categoryCode: null,
               id: "4",
               name: "name",
               purpose: "",
@@ -148,6 +148,8 @@ describe("Declaration", () => {
           elsterGroups: [
             {
               amount: 0,
+              categoryCode: "01",
+              categoryCodeTranslation: "Private",
               elsterCode: "01",
               elsterCodeTranslation: "Private",
               transactions: [
@@ -155,7 +157,31 @@ describe("Declaration", () => {
                   id: "1",
                   amount: 2,
                   category: TransactionCategory.Private,
-                  elsterCode: null,
+                  categoryCode: null,
+                  name: "name",
+                  purpose: null,
+                  selectedBookingDate: null,
+                  valutaDate: "2021-01-01",
+                  vatAmount: 0,
+                  vatRate: "5",
+                  isSplit: false,
+                },
+              ],
+            },
+          ],
+          categoryGroups: [
+            {
+              amount: 0,
+              categoryCode: "01",
+              categoryCodeTranslation: "Private",
+              elsterCode: "01",
+              elsterCodeTranslation: "Private",
+              transactions: [
+                {
+                  id: "1",
+                  amount: 2,
+                  category: TransactionCategory.Private,
+                  categoryCode: null,
                   name: "name",
                   purpose: null,
                   selectedBookingDate: null,
@@ -238,14 +264,14 @@ describe("Declaration", () => {
   describe("#categorizeTransaction", () => {
     it("should call rawQuery and return categorization response", async () => {
       const id = "1";
-      const elsterCode = "17";
+      const categoryCode = "17";
       const category = TransactionCategory.TaxPayment;
       const date = new Date().toISOString();
       const isSplit = true;
 
       // arrange
       const response: CategorizeTransactionForDeclarationResponse = {
-        elsterCode,
+        categoryCode,
         category,
         date,
       };
@@ -256,7 +282,7 @@ describe("Declaration", () => {
       // act
       const result = await declaration.categorizeTransaction({
         id,
-        elsterCode,
+        categoryCode,
         category,
         date,
         isSplit,


### PR DESCRIPTION
Rename `elsterCode` to `categoryCode`, while keep `elsterCode` for backward compatibility.