### PR TITLE
Extend subscription plans query

### DIFF
--- a/lib/graphql/subscription.ts
+++ b/lib/graphql/subscription.ts
@@ -29,6 +29,7 @@ const FETCH_PLANS = `query FetchPlans ($couponCode: String) {
         type
         title
         description
+        subtitle
         button
         featuresToggleLabel
         featureGroups {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.36.11",
+  "version": "0.36.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.36.11",
+  "version": "0.36.12",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/graphql/subscription.spec.ts
+++ b/tests/graphql/subscription.spec.ts
@@ -42,6 +42,7 @@ describe("Subscription", () => {
             type: "BASIC",
             title: "Free",
             description: "All-round business banking with virtual card",
+            subtitle: "/ month plus VAT for the first year, then much more expensive",
             button: "Open Free",
             featuresToggleLabel: "All Kontist Free features",
             featureGroups: [


### PR DESCRIPTION
#### Description

Extends the Subscription Plan's query by adding the subtitle attribute. Tests were extended but since it's mocked it doesn't make much of a difference.

Addresses [COM-100](https://kontist.atlassian.net/jira/software/c/projects/COM/boards/24?modal=detail&selectedIssue=COM-100)