### PR TITLE
Add TaxNumber and BusinessAddress to Client Model

### DIFF
--- a/lib/graphql/index.ts
+++ b/lib/graphql/index.ts
@@ -8,6 +8,8 @@ import { User } from "./user";
 import { ChangeRequest } from "./changeRequest";
 import { Declaration } from "./declaration";
 import { Document } from "./document";
+import { TaxNumber } from "./taxNumber";
+import { BusinessAddress } from "./businessAddress";
 
 export const getModels = (graphQLClient: GraphQLClient) => ({
   account: new Account(graphQLClient),
@@ -19,4 +21,6 @@ export const getModels = (graphQLClient: GraphQLClient) => ({
   changeRequest: new ChangeRequest(graphQLClient),
   declaration: new Declaration(graphQLClient),
   document: new Document(graphQLClient),
+  taxNumber: new TaxNumber(graphQLClient),
+  businessAddress: new BusinessAddress(graphQLClient),
 });

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -42,6 +42,8 @@ describe("Client", () => {
         changeRequest: {} as any,
         declaration: {} as any,
         document: {} as any,
+        taxNumber: {} as any,
+        businessAddress: {} as any,
       };
 
       // act


### PR DESCRIPTION
Extend client models to add `TaxNumber` and `BusinessAddress`.