### PR TITLE
Change client-oauth2 version to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@types/ws": "^8.2.2",
     "abab": "^2.0.3",
-    "client-oauth2": "^4.3.3",
+    "client-oauth2": "^4.3.0",
     "cross-fetch": "^3.1.5",
     "dotenv": "^15.0.0",
     "graphql": "^16.3.0",


### PR DESCRIPTION
Due to a problem in `app` with the `client-oauth2 v4.3.3` we should change it to `v4.3.0`,
they introduced a change to window.btoa in [4.3.2](https://github.com/mulesoft-labs/js-client-oauth2/releases/tag/v4.3.2)

**Addresses: [COM-331](https://kontist.atlassian.net/browse/COM-331)**