### PR TITLE
Downgrade client-oauth2 to `4.3.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/ws": "^8.2.2",
         "abab": "^2.0.3",
-        "client-oauth2": "^4.3.0",
+        "client-oauth2": "4.3.0",
         "cross-fetch": "^3.1.5",
         "dotenv": "^15.0.0",
         "graphql": "^16.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/ws": "^8.2.2",
         "abab": "^2.0.3",
-        "client-oauth2": "^4.3.3",
+        "client-oauth2": "^4.3.0",
         "cross-fetch": "^3.1.5",
         "dotenv": "^15.0.0",
         "graphql": "^16.3.0",
@@ -3457,9 +3457,9 @@
       }
     },
     "node_modules/client-oauth2": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.3.3.tgz",
-      "integrity": "sha512-k8AvUYJon0vv75ufoVo4nALYb/qwFFicO3I0+39C6xEdflqVtr+f9cy+0ZxAduoVSTfhP5DX2tY2XICAd5hy6Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.3.0.tgz",
+      "integrity": "sha512-TLybiXlrQrEg+KBPSWva5/kbxyAisLrsnj11Rl/+jpMZowQvYzfTY8DUZNuDFkX6bSSvN9cVc2xhqNh9quC6JA==",
       "dependencies": {
         "popsicle": "^12.0.5",
         "safe-buffer": "^5.2.0"
@@ -15255,9 +15255,9 @@
       "dev": true
     },
     "client-oauth2": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.3.3.tgz",
-      "integrity": "sha512-k8AvUYJon0vv75ufoVo4nALYb/qwFFicO3I0+39C6xEdflqVtr+f9cy+0ZxAduoVSTfhP5DX2tY2XICAd5hy6Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.3.0.tgz",
+      "integrity": "sha512-TLybiXlrQrEg+KBPSWva5/kbxyAisLrsnj11Rl/+jpMZowQvYzfTY8DUZNuDFkX6bSSvN9cVc2xhqNh9quC6JA==",
       "requires": {
         "popsicle": "^12.0.5",
         "safe-buffer": "^5.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.40.0",
+  "version": "0.42.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.40.0",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@types/ws": "^8.2.2",
     "abab": "^2.0.3",
-    "client-oauth2": "^4.3.0",
+    "client-oauth2": "4.3.0",
     "cross-fetch": "^3.1.5",
     "dotenv": "^15.0.0",
     "graphql": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.40.0",
+  "version": "0.42.0",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
Supplement to https://github.com/kontist/js-sdk/pull/274. Temporarily downgrades _client-oauth2_ which broke our App.

Also see [this Slack thread](https://kontist.slack.com/archives/C1DHXH7AB/p1648126568300989).