### PR TITLE
Release v0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.43.0] - 2022-03-24
+
+- Downgrades `client-oauth2` to `4.3.0` for compatibility reasons
 ## [0.38.0] - 2022-03-15
 ### Added
 - Added `discountAmount` field to `Money` type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## [0.43.0] - 2022-03-24

- Downgrades `client-oauth2` to `4.3.0` for compatibility reasons (https://github.com/kontist/js-sdk/pull/276)