### PR TITLE
Add support for custom fields in pagination queries

### DIFF
--- a/lib/graphql/interfaces.ts
+++ b/lib/graphql/interfaces.ts
@@ -1,12 +1,26 @@
 import { PageInfo } from "./schema";
+import { FetchOptions } from "./types";
 
-export interface IResultPageInterface<T> {
+export interface IResultPageInterface<
+  T,
+  FetchOptionsType = FetchOptions,
+  RestArgs extends any[] = any[]
+> {
   items: T[];
   pageInfo: PageInfo;
-  nextPage?: () => Promise<IResultPageInterface<T>>;
-  previousPage?: () => Promise<IResultPageInterface<T>>;
+  nextPage?: () => Promise<IResultPageInterface<T, FetchOptionsType, RestArgs>>;
+  previousPage?: () => Promise<
+    IResultPageInterface<T, FetchOptionsType, RestArgs>
+  >;
 }
 
-export interface IFetch<ModelType, FetchOptionsType> {
-  fetch(args?: FetchOptionsType): Promise<IResultPageInterface<ModelType>>;
+export interface IFetch<
+  ModelType,
+  FetchOptionsType,
+  RestArgs extends any[] = any[]
+> {
+  fetch(
+    args?: FetchOptionsType,
+    ...rest: RestArgs
+  ): Promise<IResultPageInterface<ModelType, FetchOptionsType, RestArgs>>;
 }

--- a/lib/graphql/resultPage.ts
+++ b/lib/graphql/resultPage.ts
@@ -2,32 +2,44 @@ import { IFetch } from "./interfaces";
 import { PageInfo } from "./schema";
 import { FetchOptions } from "./types";
 
-export class ResultPage<ModelType, FetchOptionsType = FetchOptions> {
+export class ResultPage<
+  ModelType,
+  FetchOptionsType = FetchOptions,
+  RestArgs extends any[] = any[]
+> {
   public items: ModelType[];
   public pageInfo: PageInfo;
-  public nextPage?: () => Promise<ResultPage<ModelType, FetchOptionsType>>;
-  public previousPage?: () => Promise<ResultPage<ModelType, FetchOptionsType>>;
+  public nextPage?: () => Promise<
+    ResultPage<ModelType, FetchOptionsType, RestArgs>
+  >;
+  public previousPage?: () => Promise<
+    ResultPage<ModelType, FetchOptionsType, RestArgs>
+  >;
 
   constructor(
-    model: IFetch<ModelType, FetchOptionsType>,
+    model: IFetch<ModelType, FetchOptionsType, RestArgs>,
     items: ModelType[],
     pageInfo: PageInfo,
     args: FetchOptionsType,
+    ...rest: RestArgs
   ) {
     this.items = items;
     this.pageInfo = pageInfo;
 
     if (pageInfo.hasNextPage) {
       this.nextPage = () =>
-        model.fetch({ ...args, after: pageInfo.endCursor });
+        model.fetch({ ...args, after: pageInfo.endCursor }, ...rest);
     }
 
     if (pageInfo.hasPreviousPage) {
       this.previousPage = () =>
-        model.fetch({
-          ...args,
-          before: pageInfo.startCursor,
-        });
+        model.fetch(
+          {
+            ...args,
+            before: pageInfo.startCursor,
+          },
+          ...rest
+        );
     }
   }
 }

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -59,7 +59,7 @@ const ASSET_FIELDS = `
   fullsize
 `;
 
-const TRANSACTION_FIELDS = `
+export const TRANSACTION_FIELDS = `
   id
   amount
   name

--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -310,7 +310,7 @@ export class Transaction extends IterableModel<TransactionModel> {
       hasNextPage: false,
       hasPreviousPage: false,
     };
-    return new ResultPage(this, transactions, pageInfo, args);
+    return new ResultPage(this, transactions, pageInfo, args, fields);
   }
 
   /**


### PR DESCRIPTION
Pagination logic was broken when called next/previous page because custom fields were not used.