### PR TITLE
KRP-52 Offer device signing to authorize outgoing transfers

### DIFF
--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -12,11 +12,8 @@ export type Scalars = {|
   Boolean: boolean,
   Int: number,
   Float: number,
-  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
   DateTime: any,
-  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: any,
-  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSONObject: any,
 |};
 
@@ -3507,10 +3504,10 @@ export const TransactionProjectionTypeValues = Object.freeze({
   SepaCreditTransferReturn: 'SEPA_CREDIT_TRANSFER_RETURN',
   SepaDirectDebit: 'SEPA_DIRECT_DEBIT',
   SepaDirectDebitReturn: 'SEPA_DIRECT_DEBIT_RETURN',
-  Target2CreditTransfer: 'TARGET2_CREDIT_TRANSFER',
+  Target2CreditTransfer_2: 'TARGET2_CREDIT_TRANSFER_2',
   Transfer: 'TRANSFER',
   TransferToBankAccount: 'TRANSFER_TO_BANK_ACCOUNT',
-  Target2CreditTransfer: 'Target2CreditTransfer',
+  Target2CreditTransfer1: 'Target2CreditTransfer1',
   VerificationCode: 'VERIFICATION_CODE',
   WireTransferTopup: 'WIRE_TRANSFER_TOPUP'
 });

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1556,6 +1556,8 @@ export type MutationAuthorizeChangeRequestArgs = {|
 
 
 export type MutationCancelTransferArgs = {|
+  deliveryMethod?: ?DeliveryMethod,
+  deviceId?: ?$ElementType<Scalars, 'String'>,
   id: $ElementType<Scalars, 'String'>,
   type: TransferType,
 |};
@@ -1603,8 +1605,10 @@ export type MutationChangeCardStatusArgs = {|
 
 
 export type MutationConfirmCancelTransferArgs = {|
-  authorizationToken: $ElementType<Scalars, 'String'>,
+  authorizationToken?: ?$ElementType<Scalars, 'String'>,
   confirmationId: $ElementType<Scalars, 'String'>,
+  deviceId?: ?$ElementType<Scalars, 'String'>,
+  signature?: ?$ElementType<Scalars, 'String'>,
   type: TransferType,
 |};
 

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -12,8 +12,11 @@ export type Scalars = {|
   Boolean: boolean,
   Int: number,
   Float: number,
+  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
   DateTime: any,
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: any,
+  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSONObject: any,
 |};
 
@@ -618,6 +621,7 @@ export type ConfirmFraudResponse = {|
 export type ConfirmationRequest = {|
   __typename?: 'ConfirmationRequest',
   confirmationId: $ElementType<Scalars, 'String'>,
+  stringToSign: $ElementType<Scalars, 'String'>,
 |};
 
 export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
@@ -1729,6 +1733,8 @@ export type MutationCreateTransactionSplitsArgs = {|
 
 
 export type MutationCreateTransferArgs = {|
+  deliveryMethod?: ?DeliveryMethod,
+  deviceId?: ?$ElementType<Scalars, 'String'>,
   transfer: CreateTransferInput,
 |};
 
@@ -3468,6 +3474,7 @@ export const TransactionProjectionTypeValues = Object.freeze({
   CurrencyTransactionCancellation: 'CURRENCY_TRANSACTION_CANCELLATION',
   ChargeRecallRequest: 'ChargeRecallRequest',
   CorrectionCardTransaction: 'CorrectionCardTransaction',
+  CorrectionNostro: 'CorrectionNostro',
   CorrectionSepaCreditTransfer: 'CorrectionSEPACreditTransfer',
   DebitPresentment: 'DEBIT_PRESENTMENT',
   DepositFee: 'DEPOSIT_FEE',
@@ -3481,6 +3488,7 @@ export const TransactionProjectionTypeValues = Object.freeze({
   ForcePostTransaction: 'FORCE_POST_TRANSACTION',
   ForeignPayment: 'FOREIGN_PAYMENT',
   InterestAccrued: 'INTEREST_ACCRUED',
+  InternalTransfer: 'INTERNAL_TRANSFER',
   InternationalCreditTransfer: 'INTERNATIONAL_CREDIT_TRANSFER',
   IntraCustomerTransfer: 'INTRA_CUSTOMER_TRANSFER',
   InterestExcessDeposit: 'InterestExcessDeposit',
@@ -3499,6 +3507,7 @@ export const TransactionProjectionTypeValues = Object.freeze({
   SepaCreditTransferReturn: 'SEPA_CREDIT_TRANSFER_RETURN',
   SepaDirectDebit: 'SEPA_DIRECT_DEBIT',
   SepaDirectDebitReturn: 'SEPA_DIRECT_DEBIT_RETURN',
+  Target2CreditTransfer: 'TARGET2_CREDIT_TRANSFER',
   Transfer: 'TRANSFER',
   TransferToBankAccount: 'TRANSFER_TO_BANK_ACCOUNT',
   Target2CreditTransfer: 'Target2CreditTransfer',

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -618,7 +618,7 @@ export type ConfirmFraudResponse = {|
 export type ConfirmationRequest = {|
   __typename?: 'ConfirmationRequest',
   confirmationId: $ElementType<Scalars, 'String'>,
-  stringToSign: $ElementType<Scalars, 'String'>,
+  stringToSign?: ?$ElementType<Scalars, 'String'>,
 |};
 
 export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
@@ -1638,8 +1638,10 @@ export type MutationConfirmDirectDebitRefundArgs = {|
 
 
 export type MutationConfirmTransferArgs = {|
-  authorizationToken: $ElementType<Scalars, 'String'>,
+  authorizationToken?: ?$ElementType<Scalars, 'String'>,
   confirmationId: $ElementType<Scalars, 'String'>,
+  deviceId?: ?$ElementType<Scalars, 'String'>,
+  signature?: ?$ElementType<Scalars, 'String'>,
 |};
 
 
@@ -2059,6 +2061,8 @@ export type MutationUpdateTransactionSplitsArgs = {|
 
 
 export type MutationUpdateTransferArgs = {|
+  deliveryMethod?: ?DeliveryMethod,
+  deviceId?: ?$ElementType<Scalars, 'String'>,
   transfer: UpdateTransferInput,
 |};
 
@@ -3504,10 +3508,10 @@ export const TransactionProjectionTypeValues = Object.freeze({
   SepaCreditTransferReturn: 'SEPA_CREDIT_TRANSFER_RETURN',
   SepaDirectDebit: 'SEPA_DIRECT_DEBIT',
   SepaDirectDebitReturn: 'SEPA_DIRECT_DEBIT_RETURN',
-  Target2CreditTransfer_2: 'TARGET2_CREDIT_TRANSFER_2',
   Transfer: 'TRANSFER',
   TransferToBankAccount: 'TRANSFER_TO_BANK_ACCOUNT',
   Target2CreditTransfer1: 'Target2CreditTransfer1',
+  Target2CreditTransfer2: 'Target2CreditTransfer2',
   VerificationCode: 'VERIFICATION_CODE',
   WireTransferTopup: 'WIRE_TRANSFER_TOPUP'
 });

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -582,7 +582,7 @@ export type ConfirmFraudResponse = {
 export type ConfirmationRequest = {
   __typename?: 'ConfirmationRequest';
   confirmationId: Scalars['String'];
-  stringToSign: Scalars['String'];
+  stringToSign?: Maybe<Scalars['String']>;
 };
 
 export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
@@ -1536,8 +1536,10 @@ export type MutationConfirmDirectDebitRefundArgs = {
 
 
 export type MutationConfirmTransferArgs = {
-  authorizationToken: Scalars['String'];
+  authorizationToken?: InputMaybe<Scalars['String']>;
   confirmationId: Scalars['String'];
+  deviceId?: InputMaybe<Scalars['String']>;
+  signature?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1957,6 +1959,8 @@ export type MutationUpdateTransactionSplitsArgs = {
 
 
 export type MutationUpdateTransferArgs = {
+  deliveryMethod?: InputMaybe<DeliveryMethod>;
+  deviceId?: InputMaybe<Scalars['String']>;
   transfer: UpdateTransferInput;
 };
 
@@ -3297,10 +3301,10 @@ export enum TransactionProjectionType {
   SepaCreditTransferReturn = 'SEPA_CREDIT_TRANSFER_RETURN',
   SepaDirectDebit = 'SEPA_DIRECT_DEBIT',
   SepaDirectDebitReturn = 'SEPA_DIRECT_DEBIT_RETURN',
-  Target2CreditTransfer_2 = 'TARGET2_CREDIT_TRANSFER_2',
   Transfer = 'TRANSFER',
   TransferToBankAccount = 'TRANSFER_TO_BANK_ACCOUNT',
   Target2CreditTransfer1 = 'Target2CreditTransfer1',
+  Target2CreditTransfer2 = 'Target2CreditTransfer2',
   VerificationCode = 'VERIFICATION_CODE',
   WireTransferTopup = 'WIRE_TRANSFER_TOPUP'
 }

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1454,6 +1454,8 @@ export type MutationAuthorizeChangeRequestArgs = {
 
 
 export type MutationCancelTransferArgs = {
+  deliveryMethod?: InputMaybe<DeliveryMethod>;
+  deviceId?: InputMaybe<Scalars['String']>;
   id: Scalars['String'];
   type: TransferType;
 };
@@ -1501,8 +1503,10 @@ export type MutationChangeCardStatusArgs = {
 
 
 export type MutationConfirmCancelTransferArgs = {
-  authorizationToken: Scalars['String'];
+  authorizationToken?: InputMaybe<Scalars['String']>;
   confirmationId: Scalars['String'];
+  deviceId?: InputMaybe<Scalars['String']>;
+  signature?: InputMaybe<Scalars['String']>;
   type: TransferType;
 };
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -15,11 +15,8 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
   DateTime: any;
-  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: any;
-  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSONObject: any;
 };
 
@@ -3300,10 +3297,10 @@ export enum TransactionProjectionType {
   SepaCreditTransferReturn = 'SEPA_CREDIT_TRANSFER_RETURN',
   SepaDirectDebit = 'SEPA_DIRECT_DEBIT',
   SepaDirectDebitReturn = 'SEPA_DIRECT_DEBIT_RETURN',
-  Target2CreditTransfer = 'TARGET2_CREDIT_TRANSFER',
+  Target2CreditTransfer_2 = 'TARGET2_CREDIT_TRANSFER_2',
   Transfer = 'TRANSFER',
   TransferToBankAccount = 'TRANSFER_TO_BANK_ACCOUNT',
-  Target2CreditTransfer = 'Target2CreditTransfer',
+  Target2CreditTransfer1 = 'Target2CreditTransfer1',
   VerificationCode = 'VERIFICATION_CODE',
   WireTransferTopup = 'WIRE_TRANSFER_TOPUP'
 }

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -15,8 +15,11 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
   DateTime: any;
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: any;
+  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSONObject: any;
 };
 
@@ -582,6 +585,7 @@ export type ConfirmFraudResponse = {
 export type ConfirmationRequest = {
   __typename?: 'ConfirmationRequest';
   confirmationId: Scalars['String'];
+  stringToSign: Scalars['String'];
 };
 
 export type ConfirmationRequestOrTransfer = ConfirmationRequest | Transfer;
@@ -1627,6 +1631,8 @@ export type MutationCreateTransactionSplitsArgs = {
 
 
 export type MutationCreateTransferArgs = {
+  deliveryMethod?: InputMaybe<DeliveryMethod>;
+  deviceId?: InputMaybe<Scalars['String']>;
   transfer: CreateTransferInput;
 };
 
@@ -3261,6 +3267,7 @@ export enum TransactionProjectionType {
   CurrencyTransactionCancellation = 'CURRENCY_TRANSACTION_CANCELLATION',
   ChargeRecallRequest = 'ChargeRecallRequest',
   CorrectionCardTransaction = 'CorrectionCardTransaction',
+  CorrectionNostro = 'CorrectionNostro',
   CorrectionSepaCreditTransfer = 'CorrectionSEPACreditTransfer',
   DebitPresentment = 'DEBIT_PRESENTMENT',
   DepositFee = 'DEPOSIT_FEE',
@@ -3274,6 +3281,7 @@ export enum TransactionProjectionType {
   ForcePostTransaction = 'FORCE_POST_TRANSACTION',
   ForeignPayment = 'FOREIGN_PAYMENT',
   InterestAccrued = 'INTEREST_ACCRUED',
+  InternalTransfer = 'INTERNAL_TRANSFER',
   InternationalCreditTransfer = 'INTERNATIONAL_CREDIT_TRANSFER',
   IntraCustomerTransfer = 'INTRA_CUSTOMER_TRANSFER',
   InterestExcessDeposit = 'InterestExcessDeposit',
@@ -3292,6 +3300,7 @@ export enum TransactionProjectionType {
   SepaCreditTransferReturn = 'SEPA_CREDIT_TRANSFER_RETURN',
   SepaDirectDebit = 'SEPA_DIRECT_DEBIT',
   SepaDirectDebitReturn = 'SEPA_DIRECT_DEBIT_RETURN',
+  Target2CreditTransfer = 'TARGET2_CREDIT_TRANSFER',
   Transfer = 'TRANSFER',
   TransferToBankAccount = 'TRANSFER_TO_BANK_ACCOUNT',
   Target2CreditTransfer = 'Target2CreditTransfer',

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -226,6 +226,8 @@ export class Transfer extends IterableModel<
    *
    * @param confirmationId      confirmation id obtained as a result of `transfer.createOne` call
    * @param authorizationToken  sms token
+   * @param signature           signature of string to sign obtained as a result of `transfer.createOne` call
+   * @param deviceId            device id used for device signing authorization
    * @returns                   confirmed wire transfer
    */
   public async confirmOne({

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -121,12 +121,16 @@ const CANCEL_TRANSFER = `mutation cancelTransfer(
 const CONFIRM_CANCEL_TRANSFER = `mutation confirmCancelTransfer(
   $type: TransferType!
   $confirmationId: String!
-  $authorizationToken: String!
+  $authorizationToken: String
+  $deviceId: String
+  $signature: String
 ) {
   confirmCancelTransfer(
     type: $type
     confirmationId: $confirmationId
     authorizationToken: $authorizationToken
+    deviceId: $deviceId
+    signature: $signature
   ) {
     ${TRANSFER_FIELDS}
   }

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -97,14 +97,14 @@ const CONFIRM_TRANSFERS = `mutation confirmTransfers(
 
 const CANCEL_TRANSFER = `mutation cancelTransfer(
   $type: TransferType!,
-  $id: String!
-  $deviceId: String
-  deliveryMethod: DeliveryMethod
+  $id: String!,
+  $deviceId: String,
+  $deliveryMethod: DeliveryMethod
 ) {
   cancelTransfer(
     type: $type,
     id: $id,
-    deviceId: $deviceId
+    deviceId: $deviceId,
     deliveryMethod: $deliveryMethod
   ) {
     ... on ConfirmationRequest {

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -14,7 +14,6 @@ import {
   TransferSuggestion,
   TransferType,
   UnfinishedTransfer,
-  UpdateTransferInput,
 } from "./schema";
 
 const TRANSFER_FIELDS = `

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -49,11 +49,15 @@ const CREATE_TRANSFER = `mutation createTransfer(
 
 const CONFIRM_TRANSFER = `mutation confirmTransfer(
   $confirmationId: String!
-  $authorizationToken: String!
+  $authorizationToken: String
+  $signature: String
+  $deviceId: String
 ) {
   confirmTransfer(
     confirmationId: $confirmationId
     authorizationToken: $authorizationToken
+    signature: $signature
+    deviceId: $deviceId
   ) {
     ${TRANSFER_FIELDS}
   }
@@ -224,13 +228,22 @@ export class Transfer extends IterableModel<
    * @param authorizationToken  sms token
    * @returns                   confirmed wire transfer
    */
-  public async confirmOne(
-    confirmationId: string,
-    authorizationToken: string
-  ): Promise<TransferModel> {
+  public async confirmOne({
+    confirmationId,
+    authorizationToken,
+    signature,
+    deviceId,
+  }: {
+    confirmationId: string;
+    authorizationToken?: string;
+    signature?: string;
+    deviceId?: string;
+  }): Promise<TransferModel> {
     const result = await this.client.rawQuery(CONFIRM_TRANSFER, {
       authorizationToken,
       confirmationId,
+      signature,
+      deviceId,
     });
     return result.confirmTransfer;
   }

--- a/lib/graphql/transfer.ts
+++ b/lib/graphql/transfer.ts
@@ -182,8 +182,16 @@ const GET_UNFINISHED_TRANSFERS = `
   }
 `;
 
-const UPDATE_TRANSFER = `mutation updateTransfer($transfer: UpdateTransferInput!) {
-  updateTransfer(transfer: $transfer) {
+const UPDATE_TRANSFER = `mutation updateTransfer(
+  $transfer: UpdateTransferInput!
+  $deviceId: String
+  $deliveryMethod: DeliveryMethod
+) {
+  updateTransfer(
+    transfer: $transfer
+    deviceId: $deviceId
+    deliveryMethod: $deliveryMethod
+  ) {
     ... on ConfirmationRequest {
       confirmationId
       stringToSign

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.49.42",
+  "version": "0.49.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.49.42",
+      "version": "0.49.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.49.42",
+  "version": "0.49.43",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -69,10 +69,10 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         confirmTransfer: confirmTransferResult,
       });
-      result = await transferInstance.confirmOne(
+      result = await transferInstance.confirmOne({
         confirmationId,
-        authorizationToken
-      );
+        authorizationToken,
+      });
     });
 
     it("should send confirmOne GraphQL mutation", () => {

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -7,7 +7,7 @@ import {
   StandingOrderReoccurrenceType,
   TransactionCategory,
   CreateTransferInput,
-  UnfinishedTransfer
+  UnfinishedTransfer,
 } from "../../lib/graphql/schema";
 import { createTransfer, generatePaginatedResponse } from "../helpers";
 
@@ -25,16 +25,16 @@ describe("Transfer", () => {
 
   describe("#createOne", () => {
     const transfer: CreateTransferInput = {
-        amount: 1,
-        purpose: "money1",
-        e2eId: "e2e-1",
-        reoccurrence: StandingOrderReoccurrenceType.Annually,
-        lastExecutionDate: "2022-02-01",
-        recipient: "r1",
-        iban: "iban1"
+      amount: 1,
+      purpose: "money1",
+      e2eId: "e2e-1",
+      reoccurrence: StandingOrderReoccurrenceType.Annually,
+      lastExecutionDate: "2022-02-01",
+      recipient: "r1",
+      iban: "iban1",
     };
     const createTransferResult = {
-        confirmationId: 100
+      confirmationId: 100,
     };
 
     before(async () => {
@@ -42,7 +42,7 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         createTransfer: createTransferResult,
       });
-      result = await transferInstance.createOne(transfer);
+      result = await transferInstance.createOne({ transfer });
     });
 
     it("should send createOne GraphQL mutation", () => {
@@ -69,7 +69,10 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         confirmTransfer: confirmTransferResult,
       });
-      result = await transferInstance.confirmOne(confirmationId, authorizationToken);
+      result = await transferInstance.confirmOne(
+        confirmationId,
+        authorizationToken
+      );
     });
 
     it("should send confirmOne GraphQL mutation", () => {
@@ -93,7 +96,7 @@ describe("Transfer", () => {
         reoccurrence: StandingOrderReoccurrenceType.Annually,
         lastExecutionDate: "2022-02-01",
         recipient: "r1",
-        iban: "iban1"
+        iban: "iban1",
       },
       {
         amount: 2,
@@ -102,11 +105,11 @@ describe("Transfer", () => {
         reoccurrence: StandingOrderReoccurrenceType.EverySixMonths,
         lastExecutionDate: "2022-02-02",
         recipient: "r2",
-        iban: "iban2"
+        iban: "iban2",
       },
     ];
     const createTransfersResult = {
-        confirmationId: 100
+      confirmationId: 100,
     };
 
     before(async () => {
@@ -128,7 +131,7 @@ describe("Transfer", () => {
       expect(result).to.eql(100);
     });
   });
-  
+
   describe("#confirmMany", () => {
     const confirmationId = "id-stub";
     const authorizationToken = "token";
@@ -141,7 +144,10 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         confirmTransfers: confirmTransfersResult,
       });
-      result = await transferInstance.confirmMany(confirmationId, authorizationToken);
+      result = await transferInstance.confirmMany(
+        confirmationId,
+        authorizationToken
+      );
     });
 
     it("should send confirmMany GraphQL mutation", () => {
@@ -199,7 +205,7 @@ describe("Transfer", () => {
       result = await transferInstance.confirmCancelTransfer(
         type,
         confirmationId,
-        authorizationToken,
+        authorizationToken
       );
     });
 
@@ -235,7 +241,7 @@ describe("Transfer", () => {
             hasNextPage: true,
             hasPreviousPage: false,
           },
-        }),
+        })
       );
 
       graphqlClientStub.rawQuery.onSecondCall().resolves(
@@ -246,7 +252,7 @@ describe("Transfer", () => {
             hasNextPage: false,
             hasPreviousPage: false,
           },
-        }),
+        })
       );
     });
 
@@ -288,7 +294,7 @@ describe("Transfer", () => {
               hasNextPage: false,
               hasPreviousPage: true,
             },
-          }),
+          })
         );
 
         graphqlClientStub.rawQuery.onSecondCall().resolves(
@@ -299,7 +305,7 @@ describe("Transfer", () => {
               hasNextPage: false,
               hasPreviousPage: false,
             },
-          }),
+          })
         );
 
         const firstPage = await transferInstance.fetch({
@@ -377,7 +383,9 @@ describe("Transfer", () => {
       before(async () => {
         graphqlClientStub.rawQuery.reset();
         graphqlClientStub.rawQuery.resolves({});
-        result = await transferInstance.fetch({ type: TransferType.SepaTransfer });
+        result = await transferInstance.fetch({
+          type: TransferType.SepaTransfer,
+        });
       });
 
       it("should return an empty result", () => {
@@ -397,7 +405,7 @@ describe("Transfer", () => {
       e2eId: "some-e2e-id",
       reoccurrence: StandingOrderReoccurrenceType.Annually,
       lastExecutionDate: "2022-02-02",
-      type: TransferType.StandingOrder
+      type: TransferType.StandingOrder,
     };
     const confirmationId = "standing-order:123456789";
 
@@ -405,8 +413,8 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.reset();
       graphqlClientStub.rawQuery.resolves({
         updateTransfer: {
-          confirmationId
-        }
+          confirmationId,
+        },
       });
       result = await transferInstance.update(updatePayload);
     });
@@ -426,7 +434,7 @@ describe("Transfer", () => {
   describe("update - SEPA Transfer", () => {
     const category = TransactionCategory.TaxPayment;
     const userSelectedBookingDate = new Date().toISOString();
-    const personalNote = "business travel"
+    const personalNote = "business travel";
     const updatePayload = {
       id: "some-id",
       type: TransferType.SepaTransfer,
@@ -442,7 +450,7 @@ describe("Transfer", () => {
           category,
           userSelectedBookingDate,
           personalNote,
-        }
+        },
       });
       result = await transferInstance.update(updatePayload);
     });
@@ -458,7 +466,7 @@ describe("Transfer", () => {
       expect(result).to.eql({
         category,
         userSelectedBookingDate,
-        personalNote
+        personalNote,
       });
     });
   });
@@ -466,7 +474,7 @@ describe("Transfer", () => {
   describe("update - Timed Order", () => {
     const category = TransactionCategory.TaxPayment;
     const userSelectedBookingDate = new Date().toISOString();
-    const personalNote = "best French restaurant in Berlin"
+    const personalNote = "best French restaurant in Berlin";
     const updatePayload = {
       id: "some-id",
       type: TransferType.TimedOrder,
@@ -481,8 +489,8 @@ describe("Transfer", () => {
         updateTransfer: {
           category,
           userSelectedBookingDate,
-          personalNote
-        }
+          personalNote,
+        },
       });
       result = await transferInstance.update(updatePayload);
     });
@@ -498,7 +506,7 @@ describe("Transfer", () => {
       expect(result).to.eql({
         category,
         userSelectedBookingDate,
-        personalNote
+        personalNote,
       });
     });
   });
@@ -506,12 +514,14 @@ describe("Transfer", () => {
   describe("#fetchUnfinished", () => {
     let result: UnfinishedTransfer[];
 
-    const unfinishedTransfers = [{
-      amount: 1234,
-      recipient: "John Doe",
-      iban: "DE32110101001000000029",
-      purpose: "time is money",
-    }];
+    const unfinishedTransfers = [
+      {
+        amount: 1234,
+        recipient: "John Doe",
+        iban: "DE32110101001000000029",
+        purpose: "time is money",
+      },
+    ];
 
     describe("when there are unfinished transfers", () => {
       before(async () => {

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -416,7 +416,7 @@ describe("Transfer", () => {
           confirmationId,
         },
       });
-      result = await transferInstance.update(updatePayload);
+      result = await transferInstance.update({ transfer: updatePayload });
     });
 
     it("should send updateTransfer GraphQL mutation", () => {
@@ -452,7 +452,7 @@ describe("Transfer", () => {
           personalNote,
         },
       });
-      result = await transferInstance.update(updatePayload);
+      result = await transferInstance.update({ transfer: updatePayload });
     });
 
     it("should send updateTransfer GraphQL mutation", () => {
@@ -492,7 +492,7 @@ describe("Transfer", () => {
           personalNote,
         },
       });
-      result = await transferInstance.update(updatePayload);
+      result = await transferInstance.update({ transfer: updatePayload });
     });
 
     it("should send updateTransfer GraphQL mutation", () => {

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -8,6 +8,7 @@ import {
   TransactionCategory,
   CreateTransferInput,
   UnfinishedTransfer,
+  DeliveryMethod,
 } from "../../lib/graphql/schema";
 import { createTransfer, generatePaginatedResponse } from "../helpers";
 
@@ -15,6 +16,8 @@ describe("Transfer", () => {
   let graphqlClientStub: { rawQuery: sinon.SinonStub };
   let transferInstance: TransferClass;
   let result: any;
+  const deviceId = "device-id";
+  const deliveryMethod = DeliveryMethod.DeviceSigning;
 
   before(() => {
     graphqlClientStub = {
@@ -35,6 +38,7 @@ describe("Transfer", () => {
     };
     const createTransferResult = {
       confirmationId: 100,
+      stringToSign: "string-to-sign",
     };
 
     before(async () => {
@@ -42,18 +46,22 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         createTransfer: createTransferResult,
       });
-      result = await transferInstance.createOne({ transfer });
+      result = await transferInstance.createOne({
+        transfer,
+        deviceId,
+        deliveryMethod,
+      });
     });
 
     it("should send createOne GraphQL mutation", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("createTransfer");
-      expect(variables).to.eql({ transfer });
+      expect(variables).to.eql({ transfer, deviceId, deliveryMethod });
     });
 
     it("should return confirmTransfers result", () => {
-      expect(result).to.eql(100);
+      expect(result).to.eql(createTransferResult);
     });
   });
 
@@ -79,7 +87,12 @@ describe("Transfer", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("confirmTransfer");
-      expect(variables).to.eql({ confirmationId, authorizationToken });
+      expect(variables).to.eql({
+        confirmationId,
+        authorizationToken,
+        deviceId: undefined,
+        signature: undefined,
+      });
     });
 
     it("should return confirmTransfer result", () => {
@@ -423,7 +436,11 @@ describe("Transfer", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("updateTransfer");
-      expect(variables).to.eql({ transfer: updatePayload });
+      expect(variables).to.eql({
+        transfer: updatePayload,
+        deliveryMethod: undefined,
+        deviceId: undefined,
+      });
     });
 
     it("should return updateTransfer result", () => {
@@ -459,7 +476,11 @@ describe("Transfer", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("updateTransfer");
-      expect(variables).to.eql({ transfer: updatePayload });
+      expect(variables).to.eql({
+        transfer: updatePayload,
+        deliveryMethod: undefined,
+        deviceId: undefined,
+      });
     });
 
     it("should return updateTransfer result", () => {
@@ -499,7 +520,11 @@ describe("Transfer", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("updateTransfer");
-      expect(variables).to.eql({ transfer: updatePayload });
+      expect(variables).to.eql({
+        transfer: updatePayload,
+        deliveryMethod: undefined,
+        deviceId: undefined,
+      });
     });
 
     it("should return updateTransfer result", () => {

--- a/tests/graphql/transfer.spec.ts
+++ b/tests/graphql/transfer.spec.ts
@@ -187,14 +187,19 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         cancelTransfer: cancelTransferResult,
       });
-      result = await transferInstance.cancelTransfer(type, id);
+      result = await transferInstance.cancelTransfer({ type, id });
     });
 
     it("should send cancelTransfer GraphQL mutation", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("cancelTransfer");
-      expect(variables).to.eql({ type, id });
+      expect(variables).to.eql({
+        type,
+        id,
+        deliveryMethod: undefined,
+        deviceId: undefined,
+      });
     });
 
     it("should return cancelTransfer result", () => {
@@ -215,18 +220,24 @@ describe("Transfer", () => {
       graphqlClientStub.rawQuery.resolves({
         confirmCancelTransfer: confirmCancelTransferResult,
       });
-      result = await transferInstance.confirmCancelTransfer(
+      result = await transferInstance.confirmCancelTransfer({
         type,
         confirmationId,
-        authorizationToken
-      );
+        authorizationToken,
+      });
     });
 
     it("should send confirmCancelTransfer GraphQL mutation", () => {
       expect(graphqlClientStub.rawQuery.callCount).to.equal(1);
       const [query, variables] = graphqlClientStub.rawQuery.getCall(0).args;
       expect(query).to.include("confirmCancelTransfer");
-      expect(variables).to.eql({ type, confirmationId, authorizationToken });
+      expect(variables).to.eql({
+        type,
+        confirmationId,
+        authorizationToken,
+        deviceId: undefined,
+        signature: undefined,
+      });
     });
 
     it("should return confirmCancelTransfer result", () => {


### PR DESCRIPTION
https://linear.app/ageras-group/issue/KRP-52/mobile-only-offer-device-signing-to-authorize-outgoing-wire-transfers

Based on https://github.com/kontist/backend/pull/13857