### PR TITLE
Require node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - run: npm ci
       - run: npm run build
       - run: npm run cover

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
   schedule:
-    - cron: '0 14 * * 5'
+    - cron: "0 14 * * 5"
 
 jobs:
   analyze:
@@ -17,28 +17,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
+        language: ["javascript"]
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 2
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Build
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12
-    - run: |
-        npm ci
-        npm run build
+      - name: Build
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: |
+          npm ci
+          npm run build
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: "https://registry.npmjs.org"
       - name: npm install, build and test
         run: |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "Kontist GmbH",
   "license": "Apache-2.0",
   "scripts": {
+    "prebuild": "node -e \"if (process.version.split('.')[0] !== 'v16') throw new Error('Unsupported Node version')\"",
     "build": "tsc && npx webpack",
     "test": "npm run lint && npm run build && mocha --recursive 'dist/tests/**/*.spec.js'",
     "cover": "nyc npm run test",
@@ -52,5 +53,8 @@
   },
   "bin": {
     "kontist": "./cli/index.js"
+  },
+  "engines": {
+    "node": "16"
   }
 }


### PR DESCRIPTION
It looks like `npm run build` method currently doesn't work with node 18+.

To limit confusion, let's lock the node version.