### PR TITLE
Dev-78 Remove planCopy from subscriptionPlans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.50.0] - 2023-09-11
+## Removed & Renamed
+- Removed `title, description, button, featuresToggleLabel, FeaturesGroups` from the `subscriptionPlans` query and the `SubscriptionPlan` type
+- Renamed `subtitle`into `discountSubtitle` in the `subscriptionPlans` query and the `SubscriptionPlan` type
+
 ## [0.49.0] - 2023-01-31
 ## Added
 - Updated types in schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.50.0] - 2023-09-11
-## Removed & Renamed
-- Removed `title, description, button, featuresToggleLabel, FeaturesGroups` from the `subscriptionPlans` query and the `SubscriptionPlan` type
-- Renamed `subtitle`into `discountSubtitle` in the `subscriptionPlans` query and the `SubscriptionPlan` type
+## [0.50.0] - 2023-09-12
+## Removed
+- Removed `title, description, button, featuresToggleLabel, FeaturesGroups` from the `subscriptionPlans` query
 
 ## [0.49.0] - 2023-01-31
 ## Added

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -186,6 +186,14 @@ export const ActionReasonValues = Object.freeze({
 
 export type ActionReason = $Values<typeof ActionReasonValues>;
 
+export type AddressInput = {|
+  city: $ElementType<Scalars, 'String'>,
+  country: $ElementType<Scalars, 'String'>,
+  postCode: $ElementType<Scalars, 'String'>,
+  streetName: $ElementType<Scalars, 'String'>,
+  streetNumber: $ElementType<Scalars, 'String'>,
+|};
+
 export type Asset = {|
   __typename?: 'Asset',
   assetableId: $ElementType<Scalars, 'ID'>,
@@ -290,6 +298,14 @@ export type BusinessAddress = {|
   movingDate: $ElementType<Scalars, 'DateTime'>,
   postCode: $ElementType<Scalars, 'String'>,
   street: $ElementType<Scalars, 'String'>,
+|};
+
+export type BusinessAddressInput = {|
+  city: $ElementType<Scalars, 'String'>,
+  country: $ElementType<Scalars, 'String'>,
+  postCode: $ElementType<Scalars, 'String'>,
+  streetName: $ElementType<Scalars, 'String'>,
+  streetNumber: $ElementType<Scalars, 'String'>,
 |};
 
 export type BusinessAssetForm = {|
@@ -603,9 +619,10 @@ export const CompanyTypeValues = Object.freeze({
 export type CompanyType = $Values<typeof CompanyTypeValues>;
 
 export type ConfirmChangeRequestArgs = {|
+  authorizationToken?: ?$ElementType<Scalars, 'String'>,
   changeRequestId: $ElementType<Scalars, 'String'>,
   deviceId: $ElementType<Scalars, 'String'>,
-  signature: $ElementType<Scalars, 'String'>,
+  signature?: ?$ElementType<Scalars, 'String'>,
 |};
 
 export type ConfirmChangeRequestResponse = {|
@@ -1366,8 +1383,6 @@ export type Mutation = {|
   /** Send Lead data to designated Zap to redirect lead to Agreas */
   agerasLeadRedirect: MutationResult,
   approveDeclaration: DeclarationApproval,
-  /** Assign a secret coupon code to the user who is rejected from kontax onboarding */
-  assignKontaxCouponCodeToDeclinedUser: MutationResult,
   authorizeChangeRequest: AuthorizeChangeRequestResponse,
   /** Cancel an existing Timed Order or Standing Order */
   cancelTransfer: ConfirmationRequestOrTransfer,
@@ -1383,8 +1398,6 @@ export type Mutation = {|
   changeCardPINWithChangeRequest: ConfirmationRequest,
   /** Block or unblock or close a card */
   changeCardStatus: Card,
-  /** Clear preselected plan */
-  clearPreselectedPlan: MutationResult,
   /** Confirm a Standing Order cancellation */
   confirmCancelTransfer: Transfer,
   /** Confirms adding card to Apple/Google Pay wallet */
@@ -1515,7 +1528,7 @@ export type Mutation = {|
   updateOverdraft?: ?Overdraft,
   updateReview: MutationResult,
   /** Update user fields on solaris */
-  updateSolarisUser: AuthorizeChangeRequestResponse,
+  updateSolarisUser: UserOrAuthResponse,
   /** Update user's subscription plan */
   updateSubscriptionPlan: UpdateSubscriptionPlanResult,
   /** Updates user's taxNumber */
@@ -1651,9 +1664,10 @@ export type MutationConfirmChangeCardPinArgs = {|
 
 
 export type MutationConfirmChangeRequestArgs = {|
+  authorizationToken?: ?$ElementType<Scalars, 'String'>,
   changeRequestId: $ElementType<Scalars, 'String'>,
   deviceId: $ElementType<Scalars, 'String'>,
-  signature: $ElementType<Scalars, 'String'>,
+  signature?: ?$ElementType<Scalars, 'String'>,
 |};
 
 
@@ -2053,6 +2067,7 @@ export type MutationUpdateReviewArgs = {|
 
 
 export type MutationUpdateSolarisUserArgs = {|
+  deliveryMethod?: ?DeliveryMethod,
   deviceId: $ElementType<Scalars, 'String'>,
   payload: UpdateSolarisUserInput,
 |};
@@ -2156,43 +2171,12 @@ export type MutationResult = {|
 /** NACE codes */
 export type NaceCode = {|
   __typename?: 'NACECode',
-  code: NaceCodeEnum,
+  code: $ElementType<Scalars, 'String'>,
   deDescription: $ElementType<Scalars, 'String'>,
   enDescription: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'Float'>,
+  priority: $ElementType<Scalars, 'Boolean'>,
 |};
-
-export const NaceCodeEnumValues = Object.freeze({
-  A: 'A',
-  C: 'C',
-  F: 'F',
-  G: 'G',
-  H: 'H',
-  I: 'I',
-  J: 'J',
-  J_62_01: 'J_62_01',
-  K: 'K',
-  L: 'L',
-  M_69: 'M_69',
-  M_70_1: 'M_70_1',
-  M_70_2: 'M_70_2',
-  M_71: 'M_71',
-  M_72: 'M_72',
-  M_73: 'M_73',
-  M_74_1: 'M_74_1',
-  M_74_9: 'M_74_9',
-  N_79: 'N_79',
-  N_81: 'N_81',
-  N_82: 'N_82',
-  O: 'O',
-  P: 'P',
-  Q: 'Q',
-  R: 'R',
-  R_90: 'R_90',
-  S: 'S'
-});
-
-
-export type NaceCodeEnum = $Values<typeof NaceCodeEnumValues>;
 
 export const NationalityValues = Object.freeze({
   Ad: 'AD',
@@ -2575,6 +2559,7 @@ export const PurchaseTypeValues = Object.freeze({
   Accounting: 'ACCOUNTING',
   Basic: 'BASIC',
   BasicInitial: 'BASIC_INITIAL',
+  BizTax: 'BIZ_TAX',
   Bookkeeping: 'BOOKKEEPING',
   Card: 'CARD',
   Kontax: 'KONTAX',
@@ -2613,7 +2598,7 @@ export type PushProvisioningOutput = {|
 
 export type Query = {|
   __typename?: 'Query',
-  /** Get all existing DATEV Exports */
+  /** Get all existing DATEV Exports requested by the user */
   datevExports: Array<DatevExport>,
   draftTransactions: Array<DraftTransaction>,
   /** Get all released generic features, that are needed before user creation */
@@ -3116,7 +3101,6 @@ export type SubscriptionFeatureGroup = {|
 export type SubscriptionPlan = {|
   __typename?: 'SubscriptionPlan',
   button: $ElementType<Scalars, 'String'>,
-  description: $ElementType<Scalars, 'String'>,
   featureGroups: Array<SubscriptionFeatureGroup>,
   featuresToggleLabel?: ?$ElementType<Scalars, 'String'>,
   fee: Money,
@@ -3784,7 +3768,16 @@ export type UpdateDraftTransactionInput = {|
 |};
 
 export type UpdateSolarisUserInput = {|
+  address?: ?AddressInput,
   amlConfirmed?: ?$ElementType<Scalars, 'Boolean'>,
+  businessAddress?: ?BusinessAddressInput,
+  businessPurpose?: ?$ElementType<Scalars, 'String'>,
+  businessTradingName?: ?$ElementType<Scalars, 'String'>,
+  email?: ?$ElementType<Scalars, 'String'>,
+  expectedMonthlyRevenueCents?: ?$ElementType<Scalars, 'Int'>,
+  naceCode?: ?$ElementType<Scalars, 'String'>,
+  naceCodeId?: ?$ElementType<Scalars, 'Float'>,
+  websiteSocialMedia?: ?$ElementType<Scalars, 'String'>,
 |};
 
 export type UpdateSubscriptionPlanResult = {|
@@ -3862,6 +3855,7 @@ export type User = {|
   banners?: ?Array<Banner>,
   birthDate?: ?$ElementType<Scalars, 'DateTime'>,
   birthPlace?: ?$ElementType<Scalars, 'String'>,
+  businessAddress?: ?UserBusinessAddress,
   /** User's business addresses */
   businessAddresses: Array<BusinessAddress>,
   /** Return a business asset by id */
@@ -3893,6 +3887,7 @@ export type User = {|
   emailDocument: EmailDocument,
   emailDocuments: Array<EmailDocument>,
   euerDeclaration?: ?TaxDeclaration,
+  expectedMonthlyRevenueCents?: ?$ElementType<Scalars, 'Float'>,
   /** Active user features */
   features: Array<$ElementType<Scalars, 'String'>>,
   fibuFinalCheckTasks?: ?Array<FibuFinalCheckTask>,
@@ -3931,6 +3926,7 @@ export type User = {|
   missingBusinessTaxNumberNote?: ?$ElementType<Scalars, 'String'>,
   missingPersonalTaxNumberNote?: ?$ElementType<Scalars, 'String'>,
   mobileNumber?: ?$ElementType<Scalars, 'String'>,
+  naceCodeId?: ?$ElementType<Scalars, 'Float'>,
   nationality?: ?Nationality,
   /** All push-notification types and their state */
   notifications: Array<Notification>,
@@ -3984,6 +3980,7 @@ export type User = {|
   vatNumber?: ?$ElementType<Scalars, 'String'>,
   vatPaymentFrequency?: ?PaymentFrequency,
   vatRate?: ?UserVatRate,
+  websiteSocialMedia?: ?$ElementType<Scalars, 'String'>,
   workAsHandyman?: ?$ElementType<Scalars, 'Boolean'>,
 |};
 
@@ -4102,6 +4099,16 @@ export type UserVatAnnualDeclarationArgs = {|
   year: $ElementType<Scalars, 'Int'>,
 |};
 
+/** Business Address of a User */
+export type UserBusinessAddress = {|
+  __typename?: 'UserBusinessAddress',
+  city: $ElementType<Scalars, 'String'>,
+  country: $ElementType<Scalars, 'String'>,
+  id: $ElementType<Scalars, 'ID'>,
+  postCode: $ElementType<Scalars, 'String'>,
+  street: $ElementType<Scalars, 'String'>,
+|};
+
 export const UserConfirmationValues = Object.freeze({
   AdvisorDocumentsUploaded: 'ADVISOR_DOCUMENTS_UPLOADED',
   ManualDocumentsUploaded: 'MANUAL_DOCUMENTS_UPLOADED',
@@ -4193,6 +4200,8 @@ export type UserMetadata = {|
   taxAdvisoryTermsVersionAccepted: $ElementType<Scalars, 'Boolean'>,
 |};
 
+export type UserOrAuthResponse = AuthorizeThroughDeviceSigningOrMobileNumberResponse | User;
+
 export type UserProductInput = {|
   description?: ?$ElementType<Scalars, 'String'>,
   id?: ?$ElementType<Scalars, 'String'>,
@@ -4280,6 +4289,8 @@ export type UserUpdateInput = {|
   /** Indicates user has accepted Kontist direct debit mandate */
   directDebitMandateAccepted?: ?$ElementType<Scalars, 'Boolean'>,
   economicSector?: ?$ElementType<Scalars, 'String'>,
+  /** Expected monthly revenue in euro cents */
+  expectedMonthlyRevenueCents?: ?$ElementType<Scalars, 'Int'>,
   firstName?: ?$ElementType<Scalars, 'String'>,
   gender?: ?Gender,
   hasEmployees?: ?$ElementType<Scalars, 'Boolean'>,

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1122,6 +1122,11 @@ export const GrantTypeValues = Object.freeze({
 
 export type GrantType = $Values<typeof GrantTypeValues>;
 
+export type Icon = {|
+  __typename?: 'Icon',
+  uri: $ElementType<Scalars, 'String'>,
+|};
+
 export type IdentificationDetails = {|
   __typename?: 'IdentificationDetails',
   /** The number of identifications attempted by the user */
@@ -3080,10 +3085,28 @@ export type Subscription = {|
   newTransaction: Transaction,
 |};
 
+export type SubscriptionFeature = {|
+  __typename?: 'SubscriptionFeature',
+  icon?: ?Icon,
+  title: $ElementType<Scalars, 'String'>,
+|};
+
+export type SubscriptionFeatureGroup = {|
+  __typename?: 'SubscriptionFeatureGroup',
+  features: Array<SubscriptionFeature>,
+  icon?: ?Icon,
+  title?: ?$ElementType<Scalars, 'String'>,
+|};
+
 export type SubscriptionPlan = {|
   __typename?: 'SubscriptionPlan',
-  discountSubtitle?: ?$ElementType<Scalars, 'String'>,
+  button: $ElementType<Scalars, 'String'>,
+  description: $ElementType<Scalars, 'String'>,
+  featureGroups: Array<SubscriptionFeatureGroup>,
+  featuresToggleLabel?: ?$ElementType<Scalars, 'String'>,
   fee: Money,
+  subtitle?: ?$ElementType<Scalars, 'String'>,
+  title: $ElementType<Scalars, 'String'>,
   type: PurchaseType,
 |};
 

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1122,11 +1122,6 @@ export const GrantTypeValues = Object.freeze({
 
 export type GrantType = $Values<typeof GrantTypeValues>;
 
-export type Icon = {|
-  __typename?: 'Icon',
-  uri: $ElementType<Scalars, 'String'>,
-|};
-
 export type IdentificationDetails = {|
   __typename?: 'IdentificationDetails',
   /** The number of identifications attempted by the user */
@@ -3085,27 +3080,10 @@ export type Subscription = {|
   newTransaction: Transaction,
 |};
 
-export type SubscriptionFeature = {|
-  __typename?: 'SubscriptionFeature',
-  icon?: ?Icon,
-  title: $ElementType<Scalars, 'String'>,
-|};
-
-export type SubscriptionFeatureGroup = {|
-  __typename?: 'SubscriptionFeatureGroup',
-  features: Array<SubscriptionFeature>,
-  icon?: ?Icon,
-  title?: ?$ElementType<Scalars, 'String'>,
-|};
-
 export type SubscriptionPlan = {|
   __typename?: 'SubscriptionPlan',
-  button: $ElementType<Scalars, 'String'>,
-  featureGroups: Array<SubscriptionFeatureGroup>,
-  featuresToggleLabel?: ?$ElementType<Scalars, 'String'>,
+  discountSubtitle?: ?$ElementType<Scalars, 'String'>,
   fee: Money,
-  subtitle?: ?$ElementType<Scalars, 'String'>,
-  title: $ElementType<Scalars, 'String'>,
   type: PurchaseType,
 |};
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1043,6 +1043,11 @@ export enum GrantType {
   RefreshToken = 'REFRESH_TOKEN'
 }
 
+export type Icon = {
+  __typename?: 'Icon';
+  uri: Scalars['String'];
+};
+
 export type IdentificationDetails = {
   __typename?: 'IdentificationDetails';
   /** The number of identifications attempted by the user */
@@ -2903,10 +2908,28 @@ export type Subscription = {
   newTransaction: Transaction;
 };
 
+export type SubscriptionFeature = {
+  __typename?: 'SubscriptionFeature';
+  icon?: Maybe<Icon>;
+  title: Scalars['String'];
+};
+
+export type SubscriptionFeatureGroup = {
+  __typename?: 'SubscriptionFeatureGroup';
+  features: Array<SubscriptionFeature>;
+  icon?: Maybe<Icon>;
+  title?: Maybe<Scalars['String']>;
+};
+
 export type SubscriptionPlan = {
   __typename?: 'SubscriptionPlan';
-  discountSubtitle?: Maybe<Scalars['String']>;
+  button: Scalars['String'];
+  description: Scalars['String'];
+  featureGroups: Array<SubscriptionFeatureGroup>;
+  featuresToggleLabel?: Maybe<Scalars['String']>;
   fee: Money;
+  subtitle?: Maybe<Scalars['String']>;
+  title: Scalars['String'];
   type: PurchaseType;
 };
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1043,11 +1043,6 @@ export enum GrantType {
   RefreshToken = 'REFRESH_TOKEN'
 }
 
-export type Icon = {
-  __typename?: 'Icon';
-  uri: Scalars['String'];
-};
-
 export type IdentificationDetails = {
   __typename?: 'IdentificationDetails';
   /** The number of identifications attempted by the user */
@@ -2908,27 +2903,10 @@ export type Subscription = {
   newTransaction: Transaction;
 };
 
-export type SubscriptionFeature = {
-  __typename?: 'SubscriptionFeature';
-  icon?: Maybe<Icon>;
-  title: Scalars['String'];
-};
-
-export type SubscriptionFeatureGroup = {
-  __typename?: 'SubscriptionFeatureGroup';
-  features: Array<SubscriptionFeature>;
-  icon?: Maybe<Icon>;
-  title?: Maybe<Scalars['String']>;
-};
-
 export type SubscriptionPlan = {
   __typename?: 'SubscriptionPlan';
-  button: Scalars['String'];
-  featureGroups: Array<SubscriptionFeatureGroup>;
-  featuresToggleLabel?: Maybe<Scalars['String']>;
+  discountSubtitle?: Maybe<Scalars['String']>;
   fee: Money;
-  subtitle?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
   type: PurchaseType;
 };
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -183,6 +183,14 @@ export enum ActionReason {
   WrongTaxrateAncillaryService = 'WRONG_TAXRATE_ANCILLARY_SERVICE'
 }
 
+export type AddressInput = {
+  city: Scalars['String'];
+  country: Scalars['String'];
+  postCode: Scalars['String'];
+  streetName: Scalars['String'];
+  streetNumber: Scalars['String'];
+};
+
 export type Asset = {
   __typename?: 'Asset';
   assetableId: Scalars['ID'];
@@ -275,6 +283,14 @@ export type BusinessAddress = {
   movingDate: Scalars['DateTime'];
   postCode: Scalars['String'];
   street: Scalars['String'];
+};
+
+export type BusinessAddressInput = {
+  city: Scalars['String'];
+  country: Scalars['String'];
+  postCode: Scalars['String'];
+  streetName: Scalars['String'];
+  streetNumber: Scalars['String'];
 };
 
 export type BusinessAssetForm = {
@@ -567,9 +583,10 @@ export enum CompanyType {
 }
 
 export type ConfirmChangeRequestArgs = {
+  authorizationToken?: InputMaybe<Scalars['String']>;
   changeRequestId: Scalars['String'];
   deviceId: Scalars['String'];
-  signature: Scalars['String'];
+  signature?: InputMaybe<Scalars['String']>;
 };
 
 export type ConfirmChangeRequestResponse = {
@@ -1261,8 +1278,6 @@ export type Mutation = {
   /** Send Lead data to designated Zap to redirect lead to Agreas */
   agerasLeadRedirect: MutationResult;
   approveDeclaration: DeclarationApproval;
-  /** Assign a secret coupon code to the user who is rejected from kontax onboarding */
-  assignKontaxCouponCodeToDeclinedUser: MutationResult;
   authorizeChangeRequest: AuthorizeChangeRequestResponse;
   /** Cancel an existing Timed Order or Standing Order */
   cancelTransfer: ConfirmationRequestOrTransfer;
@@ -1281,8 +1296,6 @@ export type Mutation = {
   changeCardPINWithChangeRequest: ConfirmationRequest;
   /** Block or unblock or close a card */
   changeCardStatus: Card;
-  /** Clear preselected plan */
-  clearPreselectedPlan: MutationResult;
   /** Confirm a Standing Order cancellation */
   confirmCancelTransfer: Transfer;
   /** Confirms adding card to Apple/Google Pay wallet */
@@ -1413,7 +1426,7 @@ export type Mutation = {
   updateOverdraft?: Maybe<Overdraft>;
   updateReview: MutationResult;
   /** Update user fields on solaris */
-  updateSolarisUser: AuthorizeChangeRequestResponse;
+  updateSolarisUser: UserOrAuthResponse;
   /** Update user's subscription plan */
   updateSubscriptionPlan: UpdateSubscriptionPlanResult;
   /** Updates user's taxNumber */
@@ -1549,9 +1562,10 @@ export type MutationConfirmChangeCardPinArgs = {
 
 
 export type MutationConfirmChangeRequestArgs = {
+  authorizationToken?: InputMaybe<Scalars['String']>;
   changeRequestId: Scalars['String'];
   deviceId: Scalars['String'];
-  signature: Scalars['String'];
+  signature?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1951,6 +1965,7 @@ export type MutationUpdateReviewArgs = {
 
 
 export type MutationUpdateSolarisUserArgs = {
+  deliveryMethod?: InputMaybe<DeliveryMethod>;
   deviceId: Scalars['String'];
   payload: UpdateSolarisUserInput;
 };
@@ -2054,40 +2069,12 @@ export type MutationResult = {
 /** NACE codes */
 export type NaceCode = {
   __typename?: 'NACECode';
-  code: NaceCodeEnum;
+  code: Scalars['String'];
   deDescription: Scalars['String'];
   enDescription: Scalars['String'];
+  id: Scalars['Float'];
+  priority: Scalars['Boolean'];
 };
-
-export enum NaceCodeEnum {
-  A = 'A',
-  C = 'C',
-  F = 'F',
-  G = 'G',
-  H = 'H',
-  I = 'I',
-  J = 'J',
-  J_62_01 = 'J_62_01',
-  K = 'K',
-  L = 'L',
-  M_69 = 'M_69',
-  M_70_1 = 'M_70_1',
-  M_70_2 = 'M_70_2',
-  M_71 = 'M_71',
-  M_72 = 'M_72',
-  M_73 = 'M_73',
-  M_74_1 = 'M_74_1',
-  M_74_9 = 'M_74_9',
-  N_79 = 'N_79',
-  N_81 = 'N_81',
-  N_82 = 'N_82',
-  O = 'O',
-  P = 'P',
-  Q = 'Q',
-  R = 'R',
-  R_90 = 'R_90',
-  S = 'S'
-}
 
 export enum Nationality {
   Ad = 'AD',
@@ -2449,6 +2436,7 @@ export enum PurchaseType {
   Accounting = 'ACCOUNTING',
   Basic = 'BASIC',
   BasicInitial = 'BASIC_INITIAL',
+  BizTax = 'BIZ_TAX',
   Bookkeeping = 'BOOKKEEPING',
   Card = 'CARD',
   Kontax = 'KONTAX',
@@ -2484,7 +2472,7 @@ export type PushProvisioningOutput = {
 
 export type Query = {
   __typename?: 'Query';
-  /** Get all existing DATEV Exports */
+  /** Get all existing DATEV Exports requested by the user */
   datevExports: Array<DatevExport>;
   draftTransactions: Array<DraftTransaction>;
   /** Get all released generic features, that are needed before user creation */
@@ -2936,7 +2924,6 @@ export type SubscriptionFeatureGroup = {
 export type SubscriptionPlan = {
   __typename?: 'SubscriptionPlan';
   button: Scalars['String'];
-  description: Scalars['String'];
   featureGroups: Array<SubscriptionFeatureGroup>;
   featuresToggleLabel?: Maybe<Scalars['String']>;
   fee: Money;
@@ -3559,7 +3546,16 @@ export type UpdateDraftTransactionInput = {
 };
 
 export type UpdateSolarisUserInput = {
+  address?: InputMaybe<AddressInput>;
   amlConfirmed?: InputMaybe<Scalars['Boolean']>;
+  businessAddress?: InputMaybe<BusinessAddressInput>;
+  businessPurpose?: InputMaybe<Scalars['String']>;
+  businessTradingName?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
+  expectedMonthlyRevenueCents?: InputMaybe<Scalars['Int']>;
+  naceCode?: InputMaybe<Scalars['String']>;
+  naceCodeId?: InputMaybe<Scalars['Float']>;
+  websiteSocialMedia?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateSubscriptionPlanResult = {
@@ -3637,6 +3633,7 @@ export type User = {
   banners?: Maybe<Array<Banner>>;
   birthDate?: Maybe<Scalars['DateTime']>;
   birthPlace?: Maybe<Scalars['String']>;
+  businessAddress?: Maybe<UserBusinessAddress>;
   /** User's business addresses */
   businessAddresses: Array<BusinessAddress>;
   /** Return a business asset by id */
@@ -3670,6 +3667,7 @@ export type User = {
   emailDocument: EmailDocument;
   emailDocuments: Array<EmailDocument>;
   euerDeclaration?: Maybe<TaxDeclaration>;
+  expectedMonthlyRevenueCents?: Maybe<Scalars['Float']>;
   /** Active user features */
   features: Array<Scalars['String']>;
   fibuFinalCheckTasks?: Maybe<Array<FibuFinalCheckTask>>;
@@ -3714,6 +3712,7 @@ export type User = {
   missingBusinessTaxNumberNote?: Maybe<Scalars['String']>;
   missingPersonalTaxNumberNote?: Maybe<Scalars['String']>;
   mobileNumber?: Maybe<Scalars['String']>;
+  naceCodeId?: Maybe<Scalars['Float']>;
   nationality?: Maybe<Nationality>;
   /** All push-notification types and their state */
   notifications: Array<Notification>;
@@ -3778,6 +3777,7 @@ export type User = {
   vatPaymentFrequency?: Maybe<PaymentFrequency>;
   /** @deprecated This field will be removed in an upcoming release and should now be queried from "viewer.taxDetails.vatRate" */
   vatRate?: Maybe<UserVatRate>;
+  websiteSocialMedia?: Maybe<Scalars['String']>;
   workAsHandyman?: Maybe<Scalars['Boolean']>;
 };
 
@@ -3896,6 +3896,16 @@ export type UserVatAnnualDeclarationArgs = {
   year: Scalars['Int'];
 };
 
+/** Business Address of a User */
+export type UserBusinessAddress = {
+  __typename?: 'UserBusinessAddress';
+  city: Scalars['String'];
+  country: Scalars['String'];
+  id: Scalars['ID'];
+  postCode: Scalars['String'];
+  street: Scalars['String'];
+};
+
 export enum UserConfirmation {
   AdvisorDocumentsUploaded = 'ADVISOR_DOCUMENTS_UPLOADED',
   ManualDocumentsUploaded = 'MANUAL_DOCUMENTS_UPLOADED',
@@ -3980,6 +3990,8 @@ export type UserMetadata = {
   signupCompleted: Scalars['Boolean'];
   taxAdvisoryTermsVersionAccepted: Scalars['Boolean'];
 };
+
+export type UserOrAuthResponse = AuthorizeThroughDeviceSigningOrMobileNumberResponse | User;
 
 export type UserProductInput = {
   description?: InputMaybe<Scalars['String']>;
@@ -4066,6 +4078,8 @@ export type UserUpdateInput = {
   /** Indicates user has accepted Kontist direct debit mandate */
   directDebitMandateAccepted?: InputMaybe<Scalars['Boolean']>;
   economicSector?: InputMaybe<Scalars['String']>;
+  /** Expected monthly revenue in euro cents */
+  expectedMonthlyRevenueCents?: InputMaybe<Scalars['Int']>;
   firstName?: InputMaybe<Scalars['String']>;
   gender?: InputMaybe<Gender>;
   hasEmployees?: InputMaybe<Scalars['Boolean']>;

--- a/lib/graphql/subscription.ts
+++ b/lib/graphql/subscription.ts
@@ -28,7 +28,7 @@ const FETCH_PLANS = `query fetchPlans ($couponCode: String) {
       couponValidFor
       plans {
         type
-        discountSubtitle
+        subtitle
         fee {
           amount
           discountAmount

--- a/lib/graphql/subscription.ts
+++ b/lib/graphql/subscription.ts
@@ -29,7 +29,6 @@ const FETCH_PLANS = `query fetchPlans ($couponCode: String) {
       plans {
         type
         title
-        description
         subtitle
         button
         featuresToggleLabel

--- a/lib/graphql/subscription.ts
+++ b/lib/graphql/subscription.ts
@@ -28,16 +28,7 @@ const FETCH_PLANS = `query fetchPlans ($couponCode: String) {
       couponValidFor
       plans {
         type
-        title
-        subtitle
-        button
-        featuresToggleLabel
-        featureGroups {
-          title
-          features {
-            title
-          }
-        }
+        discountSubtitle
         fee {
           amount
           discountAmount

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.49.49",
+  "version": "0.50.0",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/graphql/subscription.spec.ts
+++ b/tests/graphql/subscription.spec.ts
@@ -41,7 +41,6 @@ describe("Subscription", () => {
           {
             type: "BASIC",
             title: "Free",
-            description: "All-round business banking with virtual card",
             subtitle: "/ month plus VAT for the first year, then much more expensive",
             button: "Open Free",
             featuresToggleLabel: "All Kontist Free features",

--- a/tests/graphql/subscription.spec.ts
+++ b/tests/graphql/subscription.spec.ts
@@ -40,19 +40,7 @@ describe("Subscription", () => {
         const plans = [
           {
             type: "BASIC",
-            title: "Free",
-            subtitle: "/ month plus VAT for the first year, then much more expensive",
-            button: "Open Free",
-            featuresToggleLabel: "All Kontist Free features",
-            featureGroups: [
-              {
-                title: null,
-                features: [
-                  { title: "Unlimited SEPA transfers" },
-                  { title: "Virtual Card" },
-                ],
-              },
-            ],
+            discountSubtitle: "/ month plus VAT for the first year, then much more expensive",
             fee: {
               amount: 0,
               fullAmount: null,

--- a/tests/graphql/subscription.spec.ts
+++ b/tests/graphql/subscription.spec.ts
@@ -40,7 +40,7 @@ describe("Subscription", () => {
         const plans = [
           {
             type: "BASIC",
-            discountSubtitle: "/ month plus VAT for the first year, then much more expensive",
+            subtitle: "/ month plus VAT for the first year, then much more expensive",
             fee: {
               amount: 0,
               fullAmount: null,


### PR DESCRIPTION
🧹 
Now that we're using the webview for the mobile signup, we can use the plan copy coming from Lokalise for both webapp and mobile ([see FE pr for this)](https://github.com/kontist/webapp/pull/4408). 
So this pr removes the planCopy from subscriptionPlans query 