### PR TITLE
Release 0.50.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.50.0] - 2023-09-12
+## [0.50.3] - 2023-09-12
 ## Removed
 - Removed `title, description, button, featuresToggleLabel, FeaturesGroups` from the `subscriptionPlans` query
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.49.48",
+  "version": "0.50.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.49.48",
+      "version": "0.50.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.50.1",
+      "version": "0.50.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.50.2",
+      "version": "0.50.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
tags v0.50.1 and V.0.50.2 were already existing in our repo, so `npm version patch` brought me to v0.50.3 so I'm using this version