### PR TITLE
Dev 78/deprecate old copy fields for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.50.4] - 2023-09-20
+## Revert remove
+- Put back `title, description, button, featuresToggleLabel, featureGroups` from the `subscriptionPlans` query, for backward compatibility
+- Update the schema with the above deprecated fields
+
 ## [0.50.3] - 2023-09-12
 ## Removed
-- Removed `title, description, button, featuresToggleLabel, FeaturesGroups` from the `subscriptionPlans` query
+- Removed `title, description, button, featuresToggleLabel, featureGroups` from the `subscriptionPlans` query
 
 ## [0.49.0] - 2023-01-31
 ## Added

--- a/lib/graphql/schema.flow.js
+++ b/lib/graphql/schema.flow.js
@@ -1435,6 +1435,7 @@ export type Mutation = {|
   createReview: CreateReviewResponse,
   /** Create user's taxNumber */
   createTaxNumber: TaxNumber,
+  createTopUp: TopUpCreationResult,
   /** Create a transaction Asset and obtain an upload config */
   createTransactionAsset: CreateAssetResponse,
   /** Create transaction splits */
@@ -1465,6 +1466,7 @@ export type Mutation = {|
   deleteInvoice: MutationResult,
   /** Deletes the logo of a user's settings entry */
   deleteInvoiceLogo: MutationResult,
+  deletePaymentMethod: $ElementType<Scalars, 'Boolean'>,
   deleteQuestionnaireDocument: MutationResult,
   /** Delete user's taxNumber */
   deleteTaxNumber: MutationResult,
@@ -1763,6 +1765,11 @@ export type MutationCreateTaxNumberArgs = {|
 |};
 
 
+export type MutationCreateTopUpArgs = {|
+  topUpData: TopUpInput,
+|};
+
+
 export type MutationCreateTransactionAssetArgs = {|
   assetableType?: ?$ElementType<Scalars, 'String'>,
   filetype: $ElementType<Scalars, 'String'>,
@@ -1850,6 +1857,11 @@ export type MutationDeleteGooglePayCardTokenArgs = {|
 
 export type MutationDeleteInvoiceArgs = {|
   id: $ElementType<Scalars, 'ID'>,
+|};
+
+
+export type MutationDeletePaymentMethodArgs = {|
+  paymentMethodId: $ElementType<Scalars, 'String'>,
 |};
 
 
@@ -2502,6 +2514,13 @@ export const PaymentFrequencyValues = Object.freeze({
 
 export type PaymentFrequency = $Values<typeof PaymentFrequencyValues>;
 
+export type PaymentMethod = {|
+  __typename?: 'PaymentMethod',
+  cardBrand: $ElementType<Scalars, 'String'>,
+  cardLast4: $ElementType<Scalars, 'String'>,
+  paymentMethodId: $ElementType<Scalars, 'String'>,
+|};
+
 export type PendingTransactionVerification = {|
   __typename?: 'PendingTransactionVerification',
   /** Transaction amount */
@@ -2605,6 +2624,7 @@ export type Query = {|
   genericFeatures: Array<GenericFeature>,
   /** Determines if user device has restricted key added */
   hasDeviceRestrictedKey: $ElementType<Scalars, 'Boolean'>,
+  listPaymentMethods: Array<PaymentMethod>,
   naceCodes: Array<NaceCode>,
   status: SystemStatus,
   /** The current user information */
@@ -3100,13 +3120,18 @@ export type SubscriptionFeatureGroup = {|
 
 export type SubscriptionPlan = {|
   __typename?: 'SubscriptionPlan',
-  button: $ElementType<Scalars, 'String'>,
-  description: $ElementType<Scalars, 'String'>,
-  featureGroups: Array<SubscriptionFeatureGroup>,
+  /** @deprecated For backwards compatibility on mobile only. From now on use the button copy coming from Lokalise instead. */
+  button?: ?$ElementType<Scalars, 'String'>,
+  /** @deprecated For backwards compatibility on mobile only. From now on use the description copy coming from Lokalise instead. */
+  description?: ?$ElementType<Scalars, 'String'>,
+  /** @deprecated For backwards compatibility on mobile only. From now on use the features copy coming from Lokalise instead. */
+  featureGroups?: ?Array<SubscriptionFeatureGroup>,
+  /** @deprecated For backwards compatibility on mobile only. */
   featuresToggleLabel?: ?$ElementType<Scalars, 'String'>,
   fee: Money,
   subtitle?: ?$ElementType<Scalars, 'String'>,
-  title: $ElementType<Scalars, 'String'>,
+  /** @deprecated For backwards compatibility on mobile only. From now on use the title copy coming from Lokalise instead. */
+  title?: ?$ElementType<Scalars, 'String'>,
   type: PurchaseType,
 |};
 
@@ -3273,6 +3298,16 @@ export const ThreeStateAnswerValues = Object.freeze({
 
 
 export type ThreeStateAnswer = $Values<typeof ThreeStateAnswerValues>;
+
+export type TopUpCreationResult = {|
+  __typename?: 'TopUpCreationResult',
+  clientSecret: $ElementType<Scalars, 'String'>,
+|};
+
+export type TopUpInput = {|
+  amount: $ElementType<Scalars, 'Float'>,
+  paymentMethodId?: ?$ElementType<Scalars, 'String'>,
+|};
 
 export const TourNameValues = Object.freeze({
   BookkeepingOnboarding: 'BOOKKEEPING_ONBOARDING'

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -1333,6 +1333,7 @@ export type Mutation = {
   createReview: CreateReviewResponse;
   /** Create user's taxNumber */
   createTaxNumber: TaxNumber;
+  createTopUp: TopUpCreationResult;
   /** Create a transaction Asset and obtain an upload config */
   createTransactionAsset: CreateAssetResponse;
   /** Create transaction splits */
@@ -1363,6 +1364,7 @@ export type Mutation = {
   deleteInvoice: MutationResult;
   /** Deletes the logo of a user's settings entry */
   deleteInvoiceLogo: MutationResult;
+  deletePaymentMethod: Scalars['Boolean'];
   deleteQuestionnaireDocument: MutationResult;
   /** Delete user's taxNumber */
   deleteTaxNumber: MutationResult;
@@ -1661,6 +1663,11 @@ export type MutationCreateTaxNumberArgs = {
 };
 
 
+export type MutationCreateTopUpArgs = {
+  topUpData: TopUpInput;
+};
+
+
 export type MutationCreateTransactionAssetArgs = {
   assetableType?: InputMaybe<Scalars['String']>;
   filetype: Scalars['String'];
@@ -1748,6 +1755,11 @@ export type MutationDeleteGooglePayCardTokenArgs = {
 
 export type MutationDeleteInvoiceArgs = {
   id: Scalars['ID'];
+};
+
+
+export type MutationDeletePaymentMethodArgs = {
+  paymentMethodId: Scalars['String'];
 };
 
 
@@ -2388,6 +2400,13 @@ export enum PaymentFrequency {
   Yearly = 'YEARLY'
 }
 
+export type PaymentMethod = {
+  __typename?: 'PaymentMethod';
+  cardBrand: Scalars['String'];
+  cardLast4: Scalars['String'];
+  paymentMethodId: Scalars['String'];
+};
+
 export type PendingTransactionVerification = {
   __typename?: 'PendingTransactionVerification';
   /** Transaction amount */
@@ -2479,6 +2498,7 @@ export type Query = {
   genericFeatures: Array<GenericFeature>;
   /** Determines if user device has restricted key added */
   hasDeviceRestrictedKey: Scalars['Boolean'];
+  listPaymentMethods: Array<PaymentMethod>;
   naceCodes: Array<NaceCode>;
   status: SystemStatus;
   /** The current user information */
@@ -2923,13 +2943,18 @@ export type SubscriptionFeatureGroup = {
 
 export type SubscriptionPlan = {
   __typename?: 'SubscriptionPlan';
-  button: Scalars['String'];
-  description: Scalars['String'];
-  featureGroups: Array<SubscriptionFeatureGroup>;
+  /** @deprecated For backwards compatibility on mobile only. From now on use the button copy coming from Lokalise instead. */
+  button?: Maybe<Scalars['String']>;
+  /** @deprecated For backwards compatibility on mobile only. From now on use the description copy coming from Lokalise instead. */
+  description?: Maybe<Scalars['String']>;
+  /** @deprecated For backwards compatibility on mobile only. From now on use the features copy coming from Lokalise instead. */
+  featureGroups?: Maybe<Array<SubscriptionFeatureGroup>>;
+  /** @deprecated For backwards compatibility on mobile only. */
   featuresToggleLabel?: Maybe<Scalars['String']>;
   fee: Money;
   subtitle?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
+  /** @deprecated For backwards compatibility on mobile only. From now on use the title copy coming from Lokalise instead. */
+  title?: Maybe<Scalars['String']>;
   type: PurchaseType;
 };
 
@@ -3078,6 +3103,16 @@ export enum ThreeStateAnswer {
   NotSure = 'NOT_SURE',
   Yes = 'YES'
 }
+
+export type TopUpCreationResult = {
+  __typename?: 'TopUpCreationResult';
+  clientSecret: Scalars['String'];
+};
+
+export type TopUpInput = {
+  amount: Scalars['Float'];
+  paymentMethodId?: InputMaybe<Scalars['String']>;
+};
 
 export enum TourName {
   BookkeepingOnboarding = 'BOOKKEEPING_ONBOARDING'

--- a/lib/graphql/subscription.ts
+++ b/lib/graphql/subscription.ts
@@ -28,7 +28,17 @@ const FETCH_PLANS = `query fetchPlans ($couponCode: String) {
       couponValidFor
       plans {
         type
+        title
+        description
         subtitle
+        button
+        featuresToggleLabel
+        featureGroups {
+          title
+          features {
+            title
+          }
+        }
         fee {
           amount
           discountAmount

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontist",
-  "version": "0.50.3",
+  "version": "0.50.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kontist",
-      "version": "0.50.3",
+      "version": "0.50.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ws": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontist",
-  "version": "0.50.3",
+  "version": "0.50.4",
   "description": "Kontist client SDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/tests/graphql/subscription.spec.ts
+++ b/tests/graphql/subscription.spec.ts
@@ -40,7 +40,20 @@ describe("Subscription", () => {
         const plans = [
           {
             type: "BASIC",
+            title: "Free",
+            description: "All-round business banking with virtual card",
             subtitle: "/ month plus VAT for the first year, then much more expensive",
+            button: "Open Free",
+            featuresToggleLabel: "All Kontist Free features",
+            featureGroups: [
+              {
+                title: null,
+                features: [
+                  { title: "Unlimited SEPA transfers" },
+                  { title: "Virtual Card" },
+                ],
+              },
+            ],
             fee: {
               amount: 0,
               fullAmount: null,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This pr put backs the old fields in the `fetchPlans`query and update the schema to take into account the deprecated old copy fields which are not used anymore on the webapp (copy is coming from Lokalise now) ; we deprecate them without removing them for backward compatibility on the mobile app because some of our users are using an app version which uses a former version of our SDK (where those fields are still queried which results in errors in our BE logs, but does not impact the user experience).

At some point the users will be forced to update to a new app version using at least this current SDK version ; from then on will be able to remove those deprecated fields in both SDK and BE. 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (technical improvement, i.e. cleanup, refactor, etc.)