### PR TITLE
DEV-269 Use `isomorphic-ws` instead of `ws`

### DIFF
--- a/lib/graphql/client.ts
+++ b/lib/graphql/client.ts
@@ -1,4 +1,4 @@
-import * as ws from "ws";
+import { WebSocket } from "isomorphic-ws";
 
 import { Client, createClient } from "graphql-ws";
 import { GraphQLError, UserUnauthorizedError } from "../errors";
@@ -131,12 +131,11 @@ export class GraphQLClient {
   private createSubscriptionClient = (): Client => {
     const auth = this.getAuthHeader();
     const connectionParams = auth ? { [auth[0]]: auth[1] } : {};
-    const webSocketImpl = typeof window === "undefined" ? ws : window.WebSocket;
 
     return this.createClient({
       url: this.subscriptionEndpoint,
       connectionParams,
-      webSocketImpl,
+      webSocketImpl: WebSocket,
     })
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,10 @@
         "graphql": "^16.3.0",
         "graphql-request": "^4.0.0",
         "graphql-ws": "^5.5.5",
+        "isomorphic-ws": "^5.0.0",
         "js-sha256": "^0.9.0",
         "querystring-es3": "^0.2.1",
-        "ws": "^8.4.2"
+        "ws": "^8.16.0"
       },
       "bin": {
         "kontist": "cli/index.js"
@@ -1552,6 +1553,27 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
+    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@graphql-tools/executor-http": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz",
@@ -1636,6 +1658,27 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
+    },
+    "node_modules/@graphql-tools/executor-legacy-ws/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
       "version": "9.2.1",
@@ -2195,27 +2238,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
-    },
-    "node_modules/@graphql-tools/url-loader/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@graphql-tools/utils": {
       "version": "8.6.1",
@@ -5651,7 +5673,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "dev": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -9159,9 +9180,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10515,6 +10536,13 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
+        },
+        "ws": {
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -10586,6 +10614,13 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
+        },
+        "ws": {
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -11051,13 +11086,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
-        },
-        "ws": {
-          "version": "8.16.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-          "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -13798,7 +13826,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "dev": true,
       "requires": {}
     },
     "istanbul-lib-coverage": {
@@ -16471,9 +16498,9 @@
       }
     },
     "ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "graphql": "^16.3.0",
     "graphql-request": "^4.0.0",
     "graphql-ws": "^5.5.5",
+    "isomorphic-ws": "^5.0.0",
     "js-sha256": "^0.9.0",
     "querystring-es3": "^0.2.1",
-    "ws": "^8.4.2"
+    "ws": "^8.16.0"
   },
   "overrides": {
     "tough-cookie": "4.1.3"

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -1,5 +1,4 @@
 import * as sinon from "sinon";
-import * as ws from "ws";
 
 import { GraphQLError, UserUnauthorizedError } from "../../lib/errors";
 
@@ -551,27 +550,6 @@ describe("createSubscriptionClient", () => {
         Authorization: "Bearer dummy-token",
       });
       expect(subscriptionClient).to.equal(fakeGraphqlWsClient);
-    });
-
-    describe("when executing in a browser environment", () => {
-      before(() => {
-        (global as any).window = {
-          WebSocket: {...ws, fake: true},
-        };
-      });
-
-      after(() => {
-        (global as any).window = undefined;
-      });
-
-      it("should use the native browser WebSocket implementation", () => {
-        createClientStub.resetHistory();
-
-        client.graphQL.createSubscriptionClient();
-
-        expect(createClientStub.callCount).to.equal(1);
-        expect(createClientStub.getCall(0).args[0].webSocketImpl.fake).to.equal(true);
-      });
     });
   });
 });

--- a/tests/graphql/client.spec.ts
+++ b/tests/graphql/client.spec.ts
@@ -1,4 +1,5 @@
 import * as sinon from "sinon";
+import { WebSocket } from "isomorphic-ws";
 
 import { GraphQLError, UserUnauthorizedError } from "../../lib/errors";
 
@@ -539,16 +540,14 @@ describe("createSubscriptionClient", () => {
     it("should create a new SubscriptionClient and return it", () => {
       const subscriptionClient = client.graphQL.createSubscriptionClient();
       expect(createClientStub.callCount).to.equal(1);
-      const {url, connectionParams} = createClientStub.getCall(
-        0,
-      ).args[0];
+      const { url, connectionParams, webSocketImpl } =
+        createClientStub.getCall(0).args[0];
 
-      expect(url).to.equal(
-        `${KONTIST_SUBSCRIPTION_API_BASE_URL}/api/graphql`,
-      );
+      expect(url).to.equal(`${KONTIST_SUBSCRIPTION_API_BASE_URL}/api/graphql`);
       expect(connectionParams).to.deep.equal({
         Authorization: "Bearer dummy-token",
       });
+      expect(webSocketImpl).to.equal(WebSocket);
       expect(subscriptionClient).to.equal(fakeGraphqlWsClient);
     });
   });


### PR DESCRIPTION
Use `isomorphic-ws` instead of `ws` to fix problem with `webpack` v5 complaining about native module usage by `ws` (it's intender to be run only on Node.js)