### PR TITLE
Add Failed Card Usage type

### DIFF
--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -4571,6 +4571,7 @@ export enum TransactionProjectionType {
   CancelManualLoad = 'CANCEL_MANUAL_LOAD',
   CardTransaction = 'CARD_TRANSACTION',
   CardUsage = 'CARD_USAGE',
+  FailedCardUsage = 'FAILED_CARD_USAGE',
   CashAtmReversal = 'CASH_ATM_REVERSAL',
   CashManual = 'CASH_MANUAL',
   CashManualReversal = 'CASH_MANUAL_REVERSAL',


### PR DESCRIPTION
Enable the proper usage of transaction projection type on clients matching [backend implementation](https://github.com/kontist/backend/blob/develop/services/backendService/src/modules/banking/projections/transaction/types.ts#L15)

<img width="665" alt="image" src="https://github.com/user-attachments/assets/6c53c0cc-a5f1-465b-9b03-0b863b15ef4c" />
